### PR TITLE
Fixed HitTest for ultrawide monitors.

### DIFF
--- a/Third Party/MetroFramework/MetroFramework/Forms/MetroForm.cs
+++ b/Third Party/MetroFramework/MetroFramework/Forms/MetroForm.cs
@@ -478,7 +478,7 @@ namespace MetroFramework.Forms
         {
             //Point vPoint = PointToClient(new Point((int)lparam & 0xFFFF, (int)lparam >> 16 & 0xFFFF));
             //Point vPoint = PointToClient(new Point((Int16)lparam, (Int16)((int)lparam >> 16)));
-            Point vPoint = new Point((Int16)lparam, (Int16)((int)lparam >> 16));
+            Point vPoint = new Point((int)lparam.ToInt64() & 0xFFFF, (int)(lparam.ToInt64() >> 16) & 0xFFFF);
             int vPadding = Math.Max(Padding.Right, Padding.Bottom);
 
             if (Resizable)


### PR DESCRIPTION
I recently changed to an ultrawide monitor and now the lparam for hit testing is returning a long result. This causes an OverflowException if the lparam is not treated as a long. This PR fixes the problem.