### PR TITLE
name.com, not name.io

### DIFF
--- a/WinAuth/WinAuthMain.cs
+++ b/WinAuth/WinAuthMain.cs
@@ -145,7 +145,7 @@ namespace WinAuth
 			{new Tuple<string,string>("Itch.io", "ItchIcon.png")},
 			{new Tuple<string,string>("KickStarter", "KickStarterIcon.png")},
 			{new Tuple<string,string>("LastPass", "LastPassIcon.png")},
-			{new Tuple<string,string>("Name.io", "NameIcon.png")},
+			{new Tuple<string,string>("Name.com", "NameIcon.png")},
 			{new Tuple<string,string>("Teamviewer", "TeamviewerIcon.png")},
 			{new Tuple<string,string>("s7", string.Empty)},
 			{new Tuple<string,string>("Amazon", "AmazonIcon.png")},


### PR DESCRIPTION
Perhaps web services should be in their own category? Many of these aren't actually software. (paypal, amazon, dreamhost etc)
