### PR TITLE
implement HMAC-SHA256 and HMAC-SHA512 support

### DIFF
--- a/Authenticator/Authenticator.cs
+++ b/Authenticator/Authenticator.cs
@@ -216,7 +216,7 @@ namespace WinAuth
 			{
 				if (this.SecretKey == null && this.EncryptedData != null)
 				{
-					throw new EncrpytedSecretDataException();
+					throw new EncryptedSecretDataException();
 				}
 
 				return CalculateCode(false);
@@ -459,7 +459,7 @@ namespace WinAuth
 			if (this.RequiresPassword == true)
 			{
 				// have to decrypt to be able to re-encrypt
-				throw new EncrpytedSecretDataException();
+				throw new EncryptedSecretDataException();
 			}
 
 			if (passwordType == PasswordTypes.None)
@@ -591,7 +591,7 @@ namespace WinAuth
 
 				return changed;
 			}
-			catch (EncrpytedSecretDataException)
+			catch (EncryptedSecretDataException)
 			{
 				this.RequiresPassword = true;
 				throw;
@@ -625,7 +625,7 @@ namespace WinAuth
 				//		this.ReadXml(reader, password);
 				//	}
 				//}
-				//catch (EncrpytedSecretDataException)
+				//catch (EncryptedSecretDataException)
 				//{
 				//	this.RequiresPassword = true;
 				//	throw;
@@ -978,7 +978,7 @@ namespace WinAuth
 					// we use an explicit password to encrypt data
 					if (string.IsNullOrEmpty(password) == true)
 					{
-						throw new EncrpytedSecretDataException();
+						throw new EncryptedSecretDataException();
 					}
 					data = Authenticator.Decrypt(data, password, true);
 					if (decode == true)
@@ -1014,7 +1014,7 @@ namespace WinAuth
 					yubi.YubiData.Data = key;
 				}
 			}
-			catch (EncrpytedSecretDataException)
+			catch (EncryptedSecretDataException)
 			{
 				throw;
 			}

--- a/Authenticator/Authenticator.cs
+++ b/Authenticator/Authenticator.cs
@@ -49,1234 +49,1234 @@ using OpenNETCF.Security.Cryptography;
 
 namespace WinAuth
 {
-	/// <summary>
-	/// Class that implements base RFC 4226 an RFC 6238 authenticator
-	/// </summary>
-	public abstract class Authenticator : ICloneable
-	{
-		/// <summary>
-		/// Number of bytes making up the salt
-		/// </summary>
-		private const int SALT_LENGTH = 8;
-
-		/// <summary>
-		/// Number of iterations in PBKDF2 key generation
-		/// </summary>
-		private const int PBKDF2_ITERATIONS = 2000;
-
-		/// <summary>
-		/// Size of derived PBKDF2 key
-		/// </summary>
-		private const int PBKDF2_KEYSIZE = 256;
-
-		/// <summary>
-		/// Version for encrpytion changes
-		/// </summary>
-		private static string ENCRYPTION_HEADER = Authenticator.ByteArrayToString(Encoding.UTF8.GetBytes("WINAUTH3"));
-
-		/// <summary>
-		/// Default number of digits in code
-		/// </summary>
-		public const int DEFAULT_CODE_DIGITS = 6;
-
-		/// <summary>
-		/// Type of password to use to encrypt secret data
-		/// </summary>
-		public enum PasswordTypes
-		{
-			None = 0,
-			Explicit = 1,
-			User = 2,
-			Machine = 4,
-			YubiKeySlot1 = 8,
-			YubiKeySlot2 = 16
-		}
-
-		#region Authenticator data
-
-		/// <summary>
-		/// Serial number of authenticator
-		/// </summary>
-		//public virtual string Serial { get; set; }
-
-		/// <summary>
-		/// Secret key used for Authenticator
-		/// </summary>
-		public byte[] SecretKey { get; set; }
-
-		/// <summary>
-		/// Time difference in milliseconds of our machine and server
-		/// </summary>
-		public long ServerTimeDiff { get; set; }
-
-		/// <summary>
-		/// Time of last synced
-		/// </summary>
-		public long LastServerTime { get; set; }
-
-		/// <summary>
-		/// Type of password used to encrypt secretdata
-		/// </summary>
-		public PasswordTypes PasswordType { get; private set; }
-
-		/// <summary>
-		/// Password used to encrypt secretdata (if PasswordType == Explict)
-		/// </summary>
-		protected string Password { get; set; }
-
-		/// <summary>
-		/// Hash of secret data to detect changes
-		/// </summary>
-		protected byte[] SecretHash { get; private set; }
-
-		public bool RequiresPassword { get; private set; }
-
-		/// <summary>
-		/// The data current saved with the current encryption and/or password (might be none)
-		/// </summary>
-		protected string EncryptedData { get; private set; }
-
-		/// <summary>
-		/// Number of digits returned in code (default is 6)
-		/// </summary>
-		public int CodeDigits { get; set; }
-
-		/// <summary>
-		/// Name of issuer
-		/// </summary>
-		public virtual string Issuer { get; set; }
-
-		/// <summary>
-		/// Get/set the combined secret data value
-		/// </summary>
-		public virtual string SecretData
-		{
-			get
-			{
-				// this is the secretkey
-				return Authenticator.ByteArrayToString(SecretKey) + "\t" + this.CodeDigits.ToString();
-			}
-			set
-			{
-				if (string.IsNullOrEmpty(value) == false)
-				{
-					string[] parts = value.Split('|')[0].Split('\t');
-					SecretKey = Authenticator.StringToByteArray(parts[0]);
-					if (parts.Length > 1)
-					{
-						int digits;
-						if (int.TryParse(parts[1], out digits) == true)
-						{
-							CodeDigits = digits;
-						}
-					}
-				}
-				else
-				{
-					SecretKey = null;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Advanced script saved with authenticator so it is also encrypted
-		/// </summary>
-		//public string Script {get; set;}
-
-		/// <summary>
-		/// Get the server time since 1/1/70
-		/// </summary>
-		public long ServerTime
-		{
-			get
-			{
-				return CurrentTime + ServerTimeDiff;
-			}
-		}
-
-		/// <summary>
-		/// Calculate the code interval based on the calculated server time
-		/// </summary>
-		public long CodeInterval
-		{
-			get
-			{
-				// calculate the code interval; the server's time div 30,000
-				return (CurrentTime + ServerTimeDiff) / 30000L;
-			}
-		}
-
-		/// <summary>
-		/// Get the current code for the authenticator.
-		/// </summary>
-		/// <returns>authenticator code</returns>
-		public string CurrentCode
-		{
-			get
-			{
-				if (this.SecretKey == null && this.EncryptedData != null)
-				{
-					throw new EncryptedSecretDataException();
-				}
-
-				return CalculateCode(false);
-			}
-		}
-
-		#endregion
-
-		/// <summary>
-		/// Static initializer
-		/// </summary>
-		static Authenticator()
-		{
-			// Issue#71: remove the default .net expect header, which can cause issues (http://stackoverflow.com/questions/566437/)
-			System.Net.ServicePointManager.Expect100Continue = false;
-		}
-
-		/// <summary>
-		/// Create a new Authenticator object
-		/// </summary>
-		public Authenticator()
-		{
-			CodeDigits = DEFAULT_CODE_DIGITS;
-		}
-
-		/// <summary>
-		/// Create a new Authenticator object
-		/// </summary>
-		public Authenticator(int codeDigits)
-		{
-			CodeDigits = codeDigits;
-		}
-
-		/// <summary>
-		/// Calculate the current code for the authenticator.
-		/// </summary>
-		/// <param name="resyncTime">flag to resync time</param>
-		/// <returns>authenticator code</returns>
-		protected virtual string CalculateCode(bool resync = false, long interval = -1)
-		{
-			// sync time if required
-			if (resync == true || ServerTimeDiff == 0)
-			{
-				if (interval > 0)
-				{
-					ServerTimeDiff = (interval * 30000L) - CurrentTime;
-				}
-				else
-				{
-					Sync();
-				}
-			}
-
-			HMac hmac = new HMac(new Sha1Digest());
-			hmac.Init(new KeyParameter(SecretKey));
-
-			byte[] codeIntervalArray = BitConverter.GetBytes(CodeInterval);
-			if (BitConverter.IsLittleEndian)
-			{
-				Array.Reverse(codeIntervalArray);
-			}
-			hmac.BlockUpdate(codeIntervalArray, 0, codeIntervalArray.Length);
-
-			byte[] mac = new byte[hmac.GetMacSize()];
-			hmac.DoFinal(mac, 0);
-
-			// the last 4 bits of the mac say where the code starts (e.g. if last 4 bit are 1100, we start at byte 12)
-			int start = mac[19] & 0x0f;
-
-			// extract those 4 bytes
-			byte[] bytes = new byte[4];
-			Array.Copy(mac, start, bytes, 0, 4);
-			if (BitConverter.IsLittleEndian)
-			{
-				Array.Reverse(bytes);
-			}
-			uint fullcode = BitConverter.ToUInt32(bytes, 0) & 0x7fffffff;
-
-			// we use the last 8 digits of this code in radix 10
-			uint codemask = (uint)Math.Pow(10, CodeDigits);
-			string format = new string('0', CodeDigits);
-			string code = (fullcode % codemask).ToString(format);
-
-			return code;
-		}
-
-		/// <summary>
-		/// Synchorise this authenticator's time with server time. We update our data record with the difference from our UTC time.
-		/// </summary>
-		public abstract void Sync();
-
-		#region Load / Save
-
-		public static Authenticator ReadXmlv2(XmlReader reader, string password = null)
+    /// <summary>
+    /// Class that implements base RFC 4226 an RFC 6238 authenticator
+    /// </summary>
+    public abstract class Authenticator : ICloneable
     {
-      Authenticator authenticator = null;
-      string authenticatorType = reader.GetAttribute("type");
-      if (string.IsNullOrEmpty(authenticatorType) == false)
-      {
-        authenticatorType = authenticatorType.Replace("WindowsAuthenticator.", "WinAuth.");
-        Type type = System.Reflection.Assembly.GetExecutingAssembly().GetType(authenticatorType, false, true);
-        authenticator = Activator.CreateInstance(type) as Authenticator;
-      }
-      if (authenticator == null)
-      {
-        authenticator = new BattleNetAuthenticator();
-      }
+        /// <summary>
+        /// Number of bytes making up the salt
+        /// </summary>
+        private const int SALT_LENGTH = 8;
 
-      reader.MoveToContent();
-      if (reader.IsEmptyElement)
-      {
-        reader.Read();
-        return null;
-      }
+        /// <summary>
+        /// Number of iterations in PBKDF2 key generation
+        /// </summary>
+        private const int PBKDF2_ITERATIONS = 2000;
 
-      reader.Read();
-      while (reader.EOF == false)
-      {
-        if (reader.IsStartElement())
+        /// <summary>
+        /// Size of derived PBKDF2 key
+        /// </summary>
+        private const int PBKDF2_KEYSIZE = 256;
+
+        /// <summary>
+        /// Version for encrpytion changes
+        /// </summary>
+        private static string ENCRYPTION_HEADER = Authenticator.ByteArrayToString(Encoding.UTF8.GetBytes("WINAUTH3"));
+
+        /// <summary>
+        /// Default number of digits in code
+        /// </summary>
+        public const int DEFAULT_CODE_DIGITS = 6;
+
+        /// <summary>
+        /// Type of password to use to encrypt secret data
+        /// </summary>
+        public enum PasswordTypes
         {
-          switch (reader.Name)
-          {
-            case "servertimediff":
-              authenticator.ServerTimeDiff = reader.ReadElementContentAsLong();
-              break;
-
-						//case "restorecodeverified":
-						//	authenticator.RestoreCodeVerified = reader.ReadElementContentAsBoolean();
-						//	break;
-
-            case "secretdata":
-              string encrypted = reader.GetAttribute("encrypted");
-              string data = reader.ReadElementContentAsString();
-
-							PasswordTypes passwordType = DecodePasswordTypes(encrypted);
-
-              if (passwordType != PasswordTypes.None)
-              {
-								// this is an old version so there is no hash
-								data = DecryptSequence(data, passwordType, password, null);
-              }
-
-              authenticator.PasswordType = PasswordTypes.None;
-              authenticator.SecretData = data;
-
-              break;
-
-            default:
-							if (authenticator.ReadExtraXml(reader, reader.Name) == false)
-							{
-								reader.Skip();
-							}
-              break;
-          }
+            None = 0,
+            Explicit = 1,
+            User = 2,
+            Machine = 4,
+            YubiKeySlot1 = 8,
+            YubiKeySlot2 = 16
         }
-        else
+
+        #region Authenticator data
+
+        /// <summary>
+        /// Serial number of authenticator
+        /// </summary>
+        //public virtual string Serial { get; set; }
+
+        /// <summary>
+        /// Secret key used for Authenticator
+        /// </summary>
+        public byte[] SecretKey { get; set; }
+
+        /// <summary>
+        /// Time difference in milliseconds of our machine and server
+        /// </summary>
+        public long ServerTimeDiff { get; set; }
+
+        /// <summary>
+        /// Time of last synced
+        /// </summary>
+        public long LastServerTime { get; set; }
+
+        /// <summary>
+        /// Type of password used to encrypt secretdata
+        /// </summary>
+        public PasswordTypes PasswordType { get; private set; }
+
+        /// <summary>
+        /// Password used to encrypt secretdata (if PasswordType == Explict)
+        /// </summary>
+        protected string Password { get; set; }
+
+        /// <summary>
+        /// Hash of secret data to detect changes
+        /// </summary>
+        protected byte[] SecretHash { get; private set; }
+
+        public bool RequiresPassword { get; private set; }
+
+        /// <summary>
+        /// The data current saved with the current encryption and/or password (might be none)
+        /// </summary>
+        protected string EncryptedData { get; private set; }
+
+        /// <summary>
+        /// Number of digits returned in code (default is 6)
+        /// </summary>
+        public int CodeDigits { get; set; }
+
+        /// <summary>
+        /// Name of issuer
+        /// </summary>
+        public virtual string Issuer { get; set; }
+
+        /// <summary>
+        /// Get/set the combined secret data value
+        /// </summary>
+        public virtual string SecretData
         {
-          reader.Read();
-          break;
+            get
+            {
+                // this is the secretkey
+                return Authenticator.ByteArrayToString(SecretKey) + "\t" + this.CodeDigits.ToString();
+            }
+            set
+            {
+                if (string.IsNullOrEmpty(value) == false)
+                {
+                    string[] parts = value.Split('|')[0].Split('\t');
+                    SecretKey = Authenticator.StringToByteArray(parts[0]);
+                    if (parts.Length > 1)
+                    {
+                        int digits;
+                        if (int.TryParse(parts[1], out digits) == true)
+                        {
+                            CodeDigits = digits;
+                        }
+                    }
+                }
+                else
+                {
+                    SecretKey = null;
+                }
+            }
         }
-      }
 
-      return authenticator;
-    }
-
-		public virtual bool ReadExtraXml(XmlReader reader, string name)
-		{
-			return false;
-		}
-
-		/// <summary>
-		/// Convert the string password types into the PasswordTypes type
-		/// </summary>
-		/// <param name="passwordTypes">string version of password types</param>
-		/// <returns>PasswordTypes value</returns>
-		public static PasswordTypes DecodePasswordTypes(string passwordTypes)
-		{
-			PasswordTypes passwordType = PasswordTypes.None;
-			if (string.IsNullOrEmpty(passwordTypes) == true)
-			{
-				return passwordType;
-			}
-
-			char[] types = passwordTypes.ToCharArray();
-			for (int i = types.Length - 1; i >= 0; i--)
-			{
-				char type = types[i];
-				switch (type)
-				{
-					case 'u':
-						passwordType |= PasswordTypes.User;
-						break;
-					case 'm':
-						passwordType |= PasswordTypes.Machine;
-						break;
-					case 'y':
-						passwordType |= PasswordTypes.Explicit;
-						break;
-					case 'a':
-						passwordType |= PasswordTypes.YubiKeySlot1;
-						break;
-					case 'b':
-						passwordType |= PasswordTypes.YubiKeySlot2;
-						break;
-					default:
-						break;
-				}
-			}
-
-			return passwordType;
-		}
-
-		/// <summary>
-		/// Encode the PasswordTypes type into a string for storing in config
-		/// </summary>
-		/// <param name="passwordType">PasswordTypes value</param>
-		/// <returns>string version</returns>
-		public static string EncodePasswordTypes(PasswordTypes passwordType)
-		{
-			StringBuilder encryptedTypes = new StringBuilder();
-			if ((passwordType & PasswordTypes.Explicit) != 0)
-			{
-				encryptedTypes.Append("y");
-			}
-			if ((passwordType & PasswordTypes.User) != 0)
-			{
-				encryptedTypes.Append("u");
-			}
-			if ((passwordType & PasswordTypes.Machine) != 0)
-			{
-				encryptedTypes.Append("m");
-			}
-
-			return encryptedTypes.ToString();
-		}
-
-		public void SetEncryption(PasswordTypes passwordType, string password = null)
-		{
-			// check if still encrpyted
-			if (this.RequiresPassword == true)
-			{
-				// have to decrypt to be able to re-encrypt
-				throw new EncryptedSecretDataException();
-			}
-
-			if (passwordType == PasswordTypes.None)
-			{
-				this.RequiresPassword = false;
-				this.EncryptedData = null;
-				this.PasswordType = passwordType;
-			}
-			else
-			{
-				using (MemoryStream ms = new MemoryStream())
-				{
-					// get the plain version
-					XmlWriterSettings settings = new XmlWriterSettings();
-					settings.Indent = true;
-					settings.Encoding = Encoding.UTF8;
-					using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
-					{
-						string encrpytedData = this.EncryptedData;
-						Authenticator.PasswordTypes savedpasswordType = PasswordType;
-						try
-						{
-							PasswordType = Authenticator.PasswordTypes.None;
-							EncryptedData = null;
-							WriteToWriter(encryptedwriter);
-						}
-						finally
-						{
-							this.PasswordType = savedpasswordType;
-							this.EncryptedData = encrpytedData;
-						}
-					}
-					string data = Authenticator.ByteArrayToString(ms.ToArray());
-
-					// update secret hash
-					using (SHA1 sha1 = SHA1.Create())
-					{
-						this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
-					}
-
-					// encrypt
-					this.EncryptedData = Authenticator.EncryptSequence(data, passwordType, password, null);
-					this.PasswordType = passwordType;
-					if (this.PasswordType == PasswordTypes.Explicit)
-					{
-						this.SecretData = null;
-						this.RequiresPassword = true;
-					}
-				}
-			}
-		}
-
-		public void Protect()
-		{
-			if (this.PasswordType != PasswordTypes.None)
-			{
-				// check if the data has changed
-				//if (this.SecretData != null)
-				//{
-				//	using (SHA1 sha1 = SHA1.Create())
-				//	{
-				//		byte[] secretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
-				//		if (this.SecretHash == null || secretHash.SequenceEqual(this.SecretHash) == false)
-				//		{
-				//			// we need to encrypt changed secret data
-				//			SetEncryption(this.PasswordType, this.Password);
-				//		}
-				//	}
-				//}
-
-				this.SecretData = null;
-				this.RequiresPassword = true;
-				this.Password = null;
-			}
-		}
-
-		public bool Unprotect(string password)
-		{
-			PasswordTypes passwordType = this.PasswordType;
-			if (passwordType == PasswordTypes.None)
-			{
-				throw new InvalidOperationException("Cannot Unprotect a non-encrypted authenticator");
-			}
-
-			// decrypt
-			bool changed = false;
-			try
-			{
-				string data = Authenticator.DecryptSequence(this.EncryptedData, this.PasswordType, password, null);
-				using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
-				{
-					XmlReader reader = XmlReader.Create(ms);
-					changed = this.ReadXml(reader, password) || changed;
-				}
-				this.RequiresPassword = false;
-				// calculate hash of current secretdata
-				using (SHA1 sha1 = SHA1.Create())
-				{
-					this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
-				}
-				// keep the password until we reprotect in case data changes
-				this.Password = password;
-
-				if (changed == true)
-				{
-					// we need to encrypt changed secret data
-					using (MemoryStream ms = new MemoryStream())
-					{
-						// get the plain version
-						XmlWriterSettings settings = new XmlWriterSettings();
-						settings.Indent = true;
-						settings.Encoding = Encoding.UTF8;
-						using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
-						{
-							WriteToWriter(encryptedwriter);
-						}
-						string encrypteddata = Authenticator.ByteArrayToString(ms.ToArray());
-
-						// update secret hash
-						using (SHA1 sha1 = SHA1.Create())
-						{
-							this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
-						}
-
-						// encrypt
-						this.EncryptedData = Authenticator.EncryptSequence(encrypteddata, passwordType, password, null);
-					}
-				}
-
-				return changed;
-			}
-			catch (EncryptedSecretDataException)
-			{
-				this.RequiresPassword = true;
-				throw;
-			}
-			finally
-			{
-				this.PasswordType = passwordType;
-			}
-		}
-
-		public bool ReadXml(XmlReader reader, string password = null)
-		{
-			// decode the password type
-			string encrypted = reader.GetAttribute("encrypted");
-			PasswordTypes passwordType = DecodePasswordTypes(encrypted);
-			this.PasswordType = passwordType;
-
-			if (passwordType != PasswordTypes.None)
-			{
-				// read the encrypted text from the node
-				this.EncryptedData = reader.ReadElementContentAsString();
-				return Unprotect(password);
-
-				//// decrypt
-				//try
-				//{
-				//	string data = Authenticator.DecryptSequence(this.EncryptedData, passwordType, password);
-				//	using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
-				//	{
-				//		reader = XmlReader.Create(ms);
-				//		this.ReadXml(reader, password);
-				//	}
-				//}
-				//catch (EncryptedSecretDataException)
-				//{
-				//	this.RequiresPassword = true;
-				//	throw;
-				//}
-				//finally
-				//{
-				//	this.PasswordType = passwordType;
-				//}
-			}
-
-			reader.MoveToContent();
-			if (reader.IsEmptyElement)
-			{
-				reader.Read();
-				return false;
-			}
-
-			reader.Read();
-			while (reader.EOF == false)
-			{
-				if (reader.IsStartElement())
-				{
-					switch (reader.Name)
-					{
-						case "lastservertime":
-							LastServerTime = reader.ReadElementContentAsLong();
-							break;
-
-						case "servertimediff":
-							ServerTimeDiff = reader.ReadElementContentAsLong();
-							break;
-
-						case "secretdata":
-							SecretData = reader.ReadElementContentAsString();
-							break;
-
-						default:
-							if (ReadExtraXml(reader, reader.Name) == false)
-							{
-								reader.Skip();
-							}
-							break;
-					}
-				}
-				else
-				{
-					reader.Read();
-					break;
-				}
-			}
-
-			// check if we need to sync, or if it's been a day
-			if (this is HOTPAuthenticator)
-			{
-				// no time sync
-				return true;
-			}
-			else if (ServerTimeDiff == 0 || LastServerTime == 0 || LastServerTime < DateTime.Now.AddHours(-24).Ticks)
-			{
-				Sync();
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Write this authenticator into an XmlWriter
-		/// </summary>
-		/// <param name="writer">XmlWriter to receive authenticator</param>
-    public void WriteToWriter(XmlWriter writer)
-		{
-      writer.WriteStartElement("authenticatordata");
-      //writer.WriteAttributeString("type", this.GetType().FullName);
-			string encrypted = EncodePasswordTypes(this.PasswordType);
-			if (string.IsNullOrEmpty(encrypted) == false)
-			{
-				writer.WriteAttributeString("encrypted", encrypted);
-			}
-
-			if (this.PasswordType != PasswordTypes.None)
-			{
-				writer.WriteRaw(this.EncryptedData);
-			}
-			else
-			{
-				writer.WriteStartElement("servertimediff");
-				writer.WriteString(ServerTimeDiff.ToString());
-				writer.WriteEndElement();
-				//
-				writer.WriteStartElement("lastservertime");
-				writer.WriteString(LastServerTime.ToString());
-				writer.WriteEndElement();
-				//
-				writer.WriteStartElement("secretdata");
-				writer.WriteString(SecretData);
-				writer.WriteEndElement();
-
-				WriteExtraXml(writer);
-			}
-
-/*
-			if (passwordType != Authenticator.PasswordTypes.None)
-			{
-				//string data = this.EncryptedData;
-				//if (data == null)
-				//{
-				//	using (MemoryStream ms = new MemoryStream())
-				//	{
-				//		XmlWriterSettings settings = new XmlWriterSettings();
-				//		settings.Indent = true;
-				//		settings.Encoding = Encoding.UTF8;
-				//		using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
-				//		{
-				//			Authenticator.PasswordTypes savedpasswordType = PasswordType;
-				//			PasswordType = Authenticator.PasswordTypes.None;
-				//			WriteToWriter(encryptedwriter);
-				//			PasswordType = savedpasswordType;
-				//		}
-				//		data = Authenticator.ByteArrayToString(ms.ToArray());
-				//	}
-
-				//	data = Authenticator.EncryptSequence(data, PasswordType, Password);
-				//}
-
-				writer.WriteString(this.EncryptedData);
-				writer.WriteEndElement();
-
-				return;
-			}
-
-			//
-			writer.WriteStartElement("servertimediff");
-			writer.WriteString(ServerTimeDiff.ToString());
-			writer.WriteEndElement();
-			//
-			writer.WriteStartElement("secretdata");
-      writer.WriteString(SecretData);
-      writer.WriteEndElement();
-
-			WriteExtraXml(writer);
-*/
-
-			writer.WriteEndElement();
-		}
-
-/*
-		/// <summary>
-		/// Write this authenticator into an XmlWriter
-		/// </summary>
-		/// <param name="writer">XmlWriter to receive authenticator</param>
-		protected void WriteToWriter(XmlWriter writer, PasswordTypes passwordType)
-		{
-			if (passwordType != Authenticator.PasswordTypes.None)
-			{
-				writer.WriteStartElement("authenticatordata");
-				writer.WriteAttributeString("encrypted", EncodePasswordTypes(this.PasswordType));
-				writer.WriteString(this.EncryptedData);
-				writer.WriteEndElement();
-			}
-			else
-			{
-				writer.WriteStartElement("servertimediff");
-				writer.WriteString(ServerTimeDiff.ToString());
-				writer.WriteEndElement();
-				//
-				writer.WriteStartElement("secretdata");
-				writer.WriteString(SecretData);
-				writer.WriteEndElement();
-
-				WriteExtraXml(writer);
-			}
-		}
-*/
-
-		/// <summary>
-		/// Virtual function to write any class specific xml nodes into the writer
-		/// </summary>
-		/// <param name="writer">XmlWriter to write data</param>
-		protected virtual void WriteExtraXml(XmlWriter writer)
-		{
-		}
-
-		#endregion
-
-		#region Utility functions
-
-		/// <summary>
-		/// Create a one-time pad by generating a random block and then taking a hash of that block as many times as needed.
-		/// </summary>
-		/// <param name="length">desired pad length</param>
-		/// <returns>array of bytes conatining random data</returns>
-		protected internal static byte[] CreateOneTimePad(int length)
-		{
-			// There is a MITM vulnerability from using the standard Random call
-			// see https://docs.google.com/document/edit?id=1pf-YCgUnxR4duE8tr-xulE3rJ1Hw-Bm5aMk5tNOGU3E&hl=en
-			// in http://code.google.com/p/winauth/issues/detail?id=2
-			// so we switch out to use RNGCryptoServiceProvider instead of Random
-
-			RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
-
-			byte[] randomblock = new byte[length];
-
-			SHA1 sha1 = SHA1.Create();
-			int i = 0;
-			do
-			{
-				byte[] hashBlock = new byte[128];
-				random.GetBytes(hashBlock);
-
-				byte[] key = sha1.ComputeHash(hashBlock, 0, hashBlock.Length);
-				if (key.Length >= randomblock.Length)
-				{
-					Array.Copy(key, 0, randomblock, i, randomblock.Length);
-					break;
-				}
-				Array.Copy(key, 0, randomblock, i, key.Length);
-				i += key.Length;
-			} while (true);
-
-			return randomblock;
-		}
-
-		/// <summary>
-		/// Get the milliseconds since 1/1/70 (same as Java currentTimeMillis)
-		/// </summary>
-		public static long CurrentTime
-		{
-			get
-			{
-				return Convert.ToInt64((DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalMilliseconds);
-			}
-		}
-
-		/// <summary>
-		/// Convert a hex string into a byte array. E.g. "001f406a" -> byte[] {0x00, 0x1f, 0x40, 0x6a}
-		/// </summary>
-		/// <param name="hex">hex string to convert</param>
-		/// <returns>byte[] of hex string</returns>
-		public static byte[] StringToByteArray(string hex)
-		{
-			int len = hex.Length;
-			byte[] bytes = new byte[len / 2];
-			for (int i = 0; i < len; i += 2)
-			{
-				bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-			}
-			return bytes;
-		}
-
-		/// <summary>
-		/// Convert a byte array into a ascii hex string, e.g. byte[]{0x00,0x1f,0x40,ox6a} -> "001f406a"
-		/// </summary>
-		/// <param name="bytes">byte array to convert</param>
-		/// <returns>string version of byte array</returns>
-		public static string ByteArrayToString(byte[] bytes)
-		{
-			// Use BitConverter, but it sticks dashes in the string
-			return BitConverter.ToString(bytes).Replace("-", string.Empty);
-		}
-
-		/// <summary>
-		/// Decrypt a string sequence using the selected encryption types
-		/// </summary>
-		/// <param name="data">hex coded string sequence to decrypt</param>
-		/// <param name="encryptedTypes">Encryption types</param>
-		/// <param name="password">optional password</param>
-		/// <param name="yubidata">optional yubi data</param>
-		/// <param name="decode"></param>
-		/// <returns>decrypted string sequence</returns>
-		public static string DecryptSequence(string data, PasswordTypes encryptedTypes, string password, YubiKey yubi, bool decode = false)
-    {
-			// check for encrpytion header
-			if (data.Length < ENCRYPTION_HEADER.Length || data.IndexOf(ENCRYPTION_HEADER) != 0)
-			{
-				return DecryptSequenceNoHash(data, encryptedTypes, password, yubi, decode);
-			}
-
-			// extract salt and hash
-			using (var sha = new SHA256Managed())
-			{
-				// jump header
-				int datastart = ENCRYPTION_HEADER.Length;
-				string salt = data.Substring(datastart, Math.Min(SALT_LENGTH * 2, data.Length - datastart));
-				datastart += salt.Length;
-				string hash = data.Substring(datastart, Math.Min(sha.HashSize / 8 * 2, data.Length - datastart));
-				datastart += hash.Length;
-				data = data.Substring(datastart);
-
-				data = DecryptSequenceNoHash(data, encryptedTypes, password, yubi);
-
-				// check the hash
-				byte[] compareplain = StringToByteArray(salt + data);
-				string comparehash = ByteArrayToString(sha.ComputeHash(compareplain));
-				if (string.Compare(comparehash, hash) != 0)
-				{
-					throw new BadPasswordException();
-				}
-			}
-
-      return data;
-    }
-
-		/// <summary>
-		/// Decrypt a string sequence using the selected encryption types
-		/// </summary>
-		/// <param name="data">hex coded string sequence to decrypt</param>
-		/// <param name="encryptedTypes">Encryption types</param>
-		/// <param name="password">optional password</param>
-		/// <param name="yubidata">optional yubi data</param>
-		/// <param name="decode"></param>
-		/// <returns>decrypted string sequence</returns>
-		private static string DecryptSequenceNoHash(string data, PasswordTypes encryptedTypes, string password, YubiKey yubi, bool decode = false)
-		{
-			try
-			{
-				// reverse order they were encrypted
-				if ((encryptedTypes & PasswordTypes.Machine) != 0)
-				{
-					// we are going to decrypt with the Windows local machine key
-					byte[] cipher = Authenticator.StringToByteArray(data);
-					byte[] plain = ProtectedData.Unprotect(cipher, null, DataProtectionScope.LocalMachine);
-					if (decode == true)
-					{
-						data = Encoding.UTF8.GetString(plain, 0, plain.Length);
-					}
-					else
-					{
-						data = ByteArrayToString(plain);
-					}
-				}
-				if ((encryptedTypes & PasswordTypes.User) != 0)
-				{
-					// we are going to decrypt with the Windows User account key
-					byte[] cipher = StringToByteArray(data);
-					byte[] plain = ProtectedData.Unprotect(cipher, null, DataProtectionScope.CurrentUser);
-					if (decode == true)
-					{
-						data = Encoding.UTF8.GetString(plain, 0, plain.Length);
-					}
-					else
-					{
-						data = ByteArrayToString(plain);
-					}
-				}
-				if ((encryptedTypes & PasswordTypes.Explicit) != 0)
-				{
-					// we use an explicit password to encrypt data
-					if (string.IsNullOrEmpty(password) == true)
-					{
-						throw new EncryptedSecretDataException();
-					}
-					data = Authenticator.Decrypt(data, password, true);
-					if (decode == true)
-					{
-						byte[] plain = Authenticator.StringToByteArray(data);
-						data = Encoding.UTF8.GetString(plain, 0, plain.Length);
-					}
-				}
-				if ((encryptedTypes & PasswordTypes.YubiKeySlot1) != 0 || (encryptedTypes & PasswordTypes.YubiKeySlot2) != 0)
-				{
-					if (string.IsNullOrEmpty(yubi.Info.Error) == false)
-					{
-						throw new BadYubiKeyException("Unable to detect YubiKey");
-					}
-					if (yubi.Info.Status.VersionMajor == 0)
-					{
-						throw new BadYubiKeyException("Please insert your YubiKey");
-					}
-					int slot = ((encryptedTypes & PasswordTypes.YubiKeySlot1) != 0 ? 1 : 2);
-
-					string seed = data.Substring(0, SALT_LENGTH * 2);
-					data = data.Substring(seed.Length);
-					byte[] key = yubi.ChallengeResponse(slot, StringToByteArray(seed));
-
-					data = Authenticator.Decrypt(data, key);
-					if (decode == true)
-					{
-						byte[] plain = Authenticator.StringToByteArray(data);
-						data = Encoding.UTF8.GetString(plain, 0, plain.Length);
-					}
-
-					yubi.YubiData.Seed = seed;
-					yubi.YubiData.Data = key;
-				}
-			}
-			catch (EncryptedSecretDataException)
-			{
-				throw;
-			}
-			catch (BadYubiKeyException )
-			{
-				throw;
-			}
-			catch (ChallengeResponseException ex)
-			{
-				throw new BadYubiKeyException("Please check your YubiKey or touch the flashing button", ex);
-			}
-			catch (Exception ex)
-			{
-				throw new BadPasswordException(ex.Message, ex);
-			}
-
-			return data;
-		}
-
-		public static string EncryptSequence(string data, PasswordTypes passwordType, string password, YubiKey yubi)
-    {
-			// get hash of original
-			var random = new RNGCryptoServiceProvider();
-			byte[] saltbytes = new byte[SALT_LENGTH];
-			random.GetBytes(saltbytes);
-			string salt = ByteArrayToString(saltbytes);
-
-			string hash;
-			using (var sha = new SHA256Managed())
-			{
-        byte[] plain = StringToByteArray(salt + data);
-				hash = ByteArrayToString(sha.ComputeHash(plain));
-			}
-
-			if ((passwordType & PasswordTypes.YubiKeySlot1) != 0 || (passwordType & PasswordTypes.YubiKeySlot2) != 0)
-			{
-				if (yubi.YubiData.Length == 0)
-				{
-					byte[] seed = new byte[SALT_LENGTH];
-					random = new RNGCryptoServiceProvider();
-					random.GetBytes(seed);
-
-					// we encrypt the data using the hash of a random string from the YubiKey
-					int slot = ((passwordType & PasswordTypes.YubiKeySlot1) != 0 ? 1 : 2);
-					yubi.YubiData.Data = yubi.ChallengeResponse(slot, seed);
-					yubi.YubiData.Seed = Authenticator.ByteArrayToString(seed);
-				}
-
-				byte[] key = yubi.YubiData.Data;
-				string encrypted = Encrypt(data, key);
-
-				// test the encryption
-				string decrypted = Decrypt(encrypted, key);
-				if (string.Compare(data, decrypted) != 0)
-				{
-					throw new InvalidEncryptionException(data, password, encrypted, decrypted);
-				}
-				data = yubi.YubiData.Seed + encrypted;
-			}
-			if ((passwordType & PasswordTypes.Explicit) != 0)
-      {
-        string encrypted = Encrypt(data, password);
-
-        // test the encryption
-        string decrypted = Decrypt(encrypted, password, true);
-        if (string.Compare(data, decrypted) != 0)
+        /// <summary>
+        /// Advanced script saved with authenticator so it is also encrypted
+        /// </summary>
+        //public string Script {get; set;}
+
+        /// <summary>
+        /// Get the server time since 1/1/70
+        /// </summary>
+        public long ServerTime
         {
-          throw new InvalidEncryptionException(data, password, encrypted, decrypted);
+            get
+            {
+                return CurrentTime + ServerTimeDiff;
+            }
         }
-        data = encrypted;
-      }
-      if ((passwordType & PasswordTypes.User) != 0)
-      {
-        // we encrypt the data using the Windows User account key
-        byte[] plain = StringToByteArray(data);
-        byte[] cipher = ProtectedData.Protect(plain, null, DataProtectionScope.CurrentUser);
-        data = ByteArrayToString(cipher);
-      }
-      if ((passwordType & PasswordTypes.Machine) != 0)
-      {
-        // we encrypt the data using the Local Machine account key
-        byte[] plain = StringToByteArray(data);
-        byte[] cipher = ProtectedData.Protect(plain, null, DataProtectionScope.LocalMachine);
-        data = ByteArrayToString(cipher);
-      }
 
-			// prepend the salt + hash
-			return ENCRYPTION_HEADER + salt + hash + data;
-    }
+        /// <summary>
+        /// Calculate the code interval based on the calculated server time
+        /// </summary>
+        public long CodeInterval
+        {
+            get
+            {
+                // calculate the code interval; the server's time div 30,000
+                return (CurrentTime + ServerTimeDiff) / 30000L;
+            }
+        }
 
-		/// <summary>
-		/// Encrypt a string with a given key
-		/// </summary>
-		/// <param name="plain">data to encrypt - hex representation of byte array</param>
-		/// <param name="password">key to use to encrypt</param>
-		/// <returns>hex coded encrypted string</returns>
-		public static string Encrypt(string plain, string password)
-		{
-			byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
+        /// <summary>
+        /// Get the current code for the authenticator.
+        /// </summary>
+        /// <returns>authenticator code</returns>
+        public string CurrentCode
+        {
+            get
+            {
+                if (this.SecretKey == null && this.EncryptedData != null)
+                {
+                    throw new EncryptedSecretDataException();
+                }
 
-			// build a new salt
-			RNGCryptoServiceProvider rg = new RNGCryptoServiceProvider();
-			byte[] saltbytes = new byte[SALT_LENGTH];
-			rg.GetBytes(saltbytes);
-			string salt = Authenticator.ByteArrayToString(saltbytes);
+                return CalculateCode(false);
+            }
+        }
 
-			// build our PBKDF2 key
+        #endregion
+
+        /// <summary>
+        /// Static initializer
+        /// </summary>
+        static Authenticator()
+        {
+            // Issue#71: remove the default .net expect header, which can cause issues (http://stackoverflow.com/questions/566437/)
+            System.Net.ServicePointManager.Expect100Continue = false;
+        }
+
+        /// <summary>
+        /// Create a new Authenticator object
+        /// </summary>
+        public Authenticator()
+        {
+            CodeDigits = DEFAULT_CODE_DIGITS;
+        }
+
+        /// <summary>
+        /// Create a new Authenticator object
+        /// </summary>
+        public Authenticator(int codeDigits)
+        {
+            CodeDigits = codeDigits;
+        }
+
+        /// <summary>
+        /// Calculate the current code for the authenticator.
+        /// </summary>
+        /// <param name="resyncTime">flag to resync time</param>
+        /// <returns>authenticator code</returns>
+        protected virtual string CalculateCode(bool resync = false, long interval = -1)
+        {
+            // sync time if required
+            if (resync == true || ServerTimeDiff == 0)
+            {
+                if (interval > 0)
+                {
+                    ServerTimeDiff = (interval * 30000L) - CurrentTime;
+                }
+                else
+                {
+                    Sync();
+                }
+            }
+
+            HMac hmac = new HMac(new Sha1Digest());
+            hmac.Init(new KeyParameter(SecretKey));
+
+            byte[] codeIntervalArray = BitConverter.GetBytes(CodeInterval);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(codeIntervalArray);
+            }
+            hmac.BlockUpdate(codeIntervalArray, 0, codeIntervalArray.Length);
+
+            byte[] mac = new byte[hmac.GetMacSize()];
+            hmac.DoFinal(mac, 0);
+
+            // the last 4 bits of the mac say where the code starts (e.g. if last 4 bit are 1100, we start at byte 12)
+            int start = mac[19] & 0x0f;
+
+            // extract those 4 bytes
+            byte[] bytes = new byte[4];
+            Array.Copy(mac, start, bytes, 0, 4);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+            uint fullcode = BitConverter.ToUInt32(bytes, 0) & 0x7fffffff;
+
+            // we use the last 8 digits of this code in radix 10
+            uint codemask = (uint)Math.Pow(10, CodeDigits);
+            string format = new string('0', CodeDigits);
+            string code = (fullcode % codemask).ToString(format);
+
+            return code;
+        }
+
+        /// <summary>
+        /// Synchorise this authenticator's time with server time. We update our data record with the difference from our UTC time.
+        /// </summary>
+        public abstract void Sync();
+
+        #region Load / Save
+
+        public static Authenticator ReadXmlv2(XmlReader reader, string password = null)
+        {
+            Authenticator authenticator = null;
+            string authenticatorType = reader.GetAttribute("type");
+            if (string.IsNullOrEmpty(authenticatorType) == false)
+            {
+                authenticatorType = authenticatorType.Replace("WindowsAuthenticator.", "WinAuth.");
+                Type type = System.Reflection.Assembly.GetExecutingAssembly().GetType(authenticatorType, false, true);
+                authenticator = Activator.CreateInstance(type) as Authenticator;
+            }
+            if (authenticator == null)
+            {
+                authenticator = new BattleNetAuthenticator();
+            }
+
+            reader.MoveToContent();
+            if (reader.IsEmptyElement)
+            {
+                reader.Read();
+                return null;
+            }
+
+            reader.Read();
+            while (reader.EOF == false)
+            {
+                if (reader.IsStartElement())
+                {
+                    switch (reader.Name)
+                    {
+                        case "servertimediff":
+                            authenticator.ServerTimeDiff = reader.ReadElementContentAsLong();
+                            break;
+
+                        //case "restorecodeverified":
+                        //	authenticator.RestoreCodeVerified = reader.ReadElementContentAsBoolean();
+                        //	break;
+
+                        case "secretdata":
+                            string encrypted = reader.GetAttribute("encrypted");
+                            string data = reader.ReadElementContentAsString();
+
+                            PasswordTypes passwordType = DecodePasswordTypes(encrypted);
+
+                            if (passwordType != PasswordTypes.None)
+                            {
+                                // this is an old version so there is no hash
+                                data = DecryptSequence(data, passwordType, password, null);
+                            }
+
+                            authenticator.PasswordType = PasswordTypes.None;
+                            authenticator.SecretData = data;
+
+                            break;
+
+                        default:
+                            if (authenticator.ReadExtraXml(reader, reader.Name) == false)
+                            {
+                                reader.Skip();
+                            }
+                            break;
+                    }
+                }
+                else
+                {
+                    reader.Read();
+                    break;
+                }
+            }
+
+            return authenticator;
+        }
+
+        public virtual bool ReadExtraXml(XmlReader reader, string name)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Convert the string password types into the PasswordTypes type
+        /// </summary>
+        /// <param name="passwordTypes">string version of password types</param>
+        /// <returns>PasswordTypes value</returns>
+        public static PasswordTypes DecodePasswordTypes(string passwordTypes)
+        {
+            PasswordTypes passwordType = PasswordTypes.None;
+            if (string.IsNullOrEmpty(passwordTypes) == true)
+            {
+                return passwordType;
+            }
+
+            char[] types = passwordTypes.ToCharArray();
+            for (int i = types.Length - 1; i >= 0; i--)
+            {
+                char type = types[i];
+                switch (type)
+                {
+                    case 'u':
+                        passwordType |= PasswordTypes.User;
+                        break;
+                    case 'm':
+                        passwordType |= PasswordTypes.Machine;
+                        break;
+                    case 'y':
+                        passwordType |= PasswordTypes.Explicit;
+                        break;
+                    case 'a':
+                        passwordType |= PasswordTypes.YubiKeySlot1;
+                        break;
+                    case 'b':
+                        passwordType |= PasswordTypes.YubiKeySlot2;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return passwordType;
+        }
+
+        /// <summary>
+        /// Encode the PasswordTypes type into a string for storing in config
+        /// </summary>
+        /// <param name="passwordType">PasswordTypes value</param>
+        /// <returns>string version</returns>
+        public static string EncodePasswordTypes(PasswordTypes passwordType)
+        {
+            StringBuilder encryptedTypes = new StringBuilder();
+            if ((passwordType & PasswordTypes.Explicit) != 0)
+            {
+                encryptedTypes.Append("y");
+            }
+            if ((passwordType & PasswordTypes.User) != 0)
+            {
+                encryptedTypes.Append("u");
+            }
+            if ((passwordType & PasswordTypes.Machine) != 0)
+            {
+                encryptedTypes.Append("m");
+            }
+
+            return encryptedTypes.ToString();
+        }
+
+        public void SetEncryption(PasswordTypes passwordType, string password = null)
+        {
+            // check if still encrpyted
+            if (this.RequiresPassword == true)
+            {
+                // have to decrypt to be able to re-encrypt
+                throw new EncryptedSecretDataException();
+            }
+
+            if (passwordType == PasswordTypes.None)
+            {
+                this.RequiresPassword = false;
+                this.EncryptedData = null;
+                this.PasswordType = passwordType;
+            }
+            else
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    // get the plain version
+                    XmlWriterSettings settings = new XmlWriterSettings();
+                    settings.Indent = true;
+                    settings.Encoding = Encoding.UTF8;
+                    using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
+                    {
+                        string encrpytedData = this.EncryptedData;
+                        Authenticator.PasswordTypes savedpasswordType = PasswordType;
+                        try
+                        {
+                            PasswordType = Authenticator.PasswordTypes.None;
+                            EncryptedData = null;
+                            WriteToWriter(encryptedwriter);
+                        }
+                        finally
+                        {
+                            this.PasswordType = savedpasswordType;
+                            this.EncryptedData = encrpytedData;
+                        }
+                    }
+                    string data = Authenticator.ByteArrayToString(ms.ToArray());
+
+                    // update secret hash
+                    using (SHA1 sha1 = SHA1.Create())
+                    {
+                        this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
+                    }
+
+                    // encrypt
+                    this.EncryptedData = Authenticator.EncryptSequence(data, passwordType, password, null);
+                    this.PasswordType = passwordType;
+                    if (this.PasswordType == PasswordTypes.Explicit)
+                    {
+                        this.SecretData = null;
+                        this.RequiresPassword = true;
+                    }
+                }
+            }
+        }
+
+        public void Protect()
+        {
+            if (this.PasswordType != PasswordTypes.None)
+            {
+                // check if the data has changed
+                //if (this.SecretData != null)
+                //{
+                //	using (SHA1 sha1 = SHA1.Create())
+                //	{
+                //		byte[] secretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
+                //		if (this.SecretHash == null || secretHash.SequenceEqual(this.SecretHash) == false)
+                //		{
+                //			// we need to encrypt changed secret data
+                //			SetEncryption(this.PasswordType, this.Password);
+                //		}
+                //	}
+                //}
+
+                this.SecretData = null;
+                this.RequiresPassword = true;
+                this.Password = null;
+            }
+        }
+
+        public bool Unprotect(string password)
+        {
+            PasswordTypes passwordType = this.PasswordType;
+            if (passwordType == PasswordTypes.None)
+            {
+                throw new InvalidOperationException("Cannot Unprotect a non-encrypted authenticator");
+            }
+
+            // decrypt
+            bool changed = false;
+            try
+            {
+                string data = Authenticator.DecryptSequence(this.EncryptedData, this.PasswordType, password, null);
+                using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
+                {
+                    XmlReader reader = XmlReader.Create(ms);
+                    changed = this.ReadXml(reader, password) || changed;
+                }
+                this.RequiresPassword = false;
+                // calculate hash of current secretdata
+                using (SHA1 sha1 = SHA1.Create())
+                {
+                    this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
+                }
+                // keep the password until we reprotect in case data changes
+                this.Password = password;
+
+                if (changed == true)
+                {
+                    // we need to encrypt changed secret data
+                    using (MemoryStream ms = new MemoryStream())
+                    {
+                        // get the plain version
+                        XmlWriterSettings settings = new XmlWriterSettings();
+                        settings.Indent = true;
+                        settings.Encoding = Encoding.UTF8;
+                        using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
+                        {
+                            WriteToWriter(encryptedwriter);
+                        }
+                        string encrypteddata = Authenticator.ByteArrayToString(ms.ToArray());
+
+                        // update secret hash
+                        using (SHA1 sha1 = SHA1.Create())
+                        {
+                            this.SecretHash = sha1.ComputeHash(Encoding.UTF8.GetBytes(this.SecretData));
+                        }
+
+                        // encrypt
+                        this.EncryptedData = Authenticator.EncryptSequence(encrypteddata, passwordType, password, null);
+                    }
+                }
+
+                return changed;
+            }
+            catch (EncryptedSecretDataException)
+            {
+                this.RequiresPassword = true;
+                throw;
+            }
+            finally
+            {
+                this.PasswordType = passwordType;
+            }
+        }
+
+        public bool ReadXml(XmlReader reader, string password = null)
+        {
+            // decode the password type
+            string encrypted = reader.GetAttribute("encrypted");
+            PasswordTypes passwordType = DecodePasswordTypes(encrypted);
+            this.PasswordType = passwordType;
+
+            if (passwordType != PasswordTypes.None)
+            {
+                // read the encrypted text from the node
+                this.EncryptedData = reader.ReadElementContentAsString();
+                return Unprotect(password);
+
+                //// decrypt
+                //try
+                //{
+                //	string data = Authenticator.DecryptSequence(this.EncryptedData, passwordType, password);
+                //	using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
+                //	{
+                //		reader = XmlReader.Create(ms);
+                //		this.ReadXml(reader, password);
+                //	}
+                //}
+                //catch (EncryptedSecretDataException)
+                //{
+                //	this.RequiresPassword = true;
+                //	throw;
+                //}
+                //finally
+                //{
+                //	this.PasswordType = passwordType;
+                //}
+            }
+
+            reader.MoveToContent();
+            if (reader.IsEmptyElement)
+            {
+                reader.Read();
+                return false;
+            }
+
+            reader.Read();
+            while (reader.EOF == false)
+            {
+                if (reader.IsStartElement())
+                {
+                    switch (reader.Name)
+                    {
+                        case "lastservertime":
+                            LastServerTime = reader.ReadElementContentAsLong();
+                            break;
+
+                        case "servertimediff":
+                            ServerTimeDiff = reader.ReadElementContentAsLong();
+                            break;
+
+                        case "secretdata":
+                            SecretData = reader.ReadElementContentAsString();
+                            break;
+
+                        default:
+                            if (ReadExtraXml(reader, reader.Name) == false)
+                            {
+                                reader.Skip();
+                            }
+                            break;
+                    }
+                }
+                else
+                {
+                    reader.Read();
+                    break;
+                }
+            }
+
+            // check if we need to sync, or if it's been a day
+            if (this is HOTPAuthenticator)
+            {
+                // no time sync
+                return true;
+            }
+            else if (ServerTimeDiff == 0 || LastServerTime == 0 || LastServerTime < DateTime.Now.AddHours(-24).Ticks)
+            {
+                Sync();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Write this authenticator into an XmlWriter
+        /// </summary>
+        /// <param name="writer">XmlWriter to receive authenticator</param>
+        public void WriteToWriter(XmlWriter writer)
+        {
+            writer.WriteStartElement("authenticatordata");
+            //writer.WriteAttributeString("type", this.GetType().FullName);
+            string encrypted = EncodePasswordTypes(this.PasswordType);
+            if (string.IsNullOrEmpty(encrypted) == false)
+            {
+                writer.WriteAttributeString("encrypted", encrypted);
+            }
+
+            if (this.PasswordType != PasswordTypes.None)
+            {
+                writer.WriteRaw(this.EncryptedData);
+            }
+            else
+            {
+                writer.WriteStartElement("servertimediff");
+                writer.WriteString(ServerTimeDiff.ToString());
+                writer.WriteEndElement();
+                //
+                writer.WriteStartElement("lastservertime");
+                writer.WriteString(LastServerTime.ToString());
+                writer.WriteEndElement();
+                //
+                writer.WriteStartElement("secretdata");
+                writer.WriteString(SecretData);
+                writer.WriteEndElement();
+
+                WriteExtraXml(writer);
+            }
+
+            /*
+                        if (passwordType != Authenticator.PasswordTypes.None)
+                        {
+                            //string data = this.EncryptedData;
+                            //if (data == null)
+                            //{
+                            //	using (MemoryStream ms = new MemoryStream())
+                            //	{
+                            //		XmlWriterSettings settings = new XmlWriterSettings();
+                            //		settings.Indent = true;
+                            //		settings.Encoding = Encoding.UTF8;
+                            //		using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
+                            //		{
+                            //			Authenticator.PasswordTypes savedpasswordType = PasswordType;
+                            //			PasswordType = Authenticator.PasswordTypes.None;
+                            //			WriteToWriter(encryptedwriter);
+                            //			PasswordType = savedpasswordType;
+                            //		}
+                            //		data = Authenticator.ByteArrayToString(ms.ToArray());
+                            //	}
+
+                            //	data = Authenticator.EncryptSequence(data, PasswordType, Password);
+                            //}
+
+                            writer.WriteString(this.EncryptedData);
+                            writer.WriteEndElement();
+
+                            return;
+                        }
+
+                        //
+                        writer.WriteStartElement("servertimediff");
+                        writer.WriteString(ServerTimeDiff.ToString());
+                        writer.WriteEndElement();
+                        //
+                        writer.WriteStartElement("secretdata");
+                  writer.WriteString(SecretData);
+                  writer.WriteEndElement();
+
+                        WriteExtraXml(writer);
+            */
+
+            writer.WriteEndElement();
+        }
+
+        /*
+                /// <summary>
+                /// Write this authenticator into an XmlWriter
+                /// </summary>
+                /// <param name="writer">XmlWriter to receive authenticator</param>
+                protected void WriteToWriter(XmlWriter writer, PasswordTypes passwordType)
+                {
+                    if (passwordType != Authenticator.PasswordTypes.None)
+                    {
+                        writer.WriteStartElement("authenticatordata");
+                        writer.WriteAttributeString("encrypted", EncodePasswordTypes(this.PasswordType));
+                        writer.WriteString(this.EncryptedData);
+                        writer.WriteEndElement();
+                    }
+                    else
+                    {
+                        writer.WriteStartElement("servertimediff");
+                        writer.WriteString(ServerTimeDiff.ToString());
+                        writer.WriteEndElement();
+                        //
+                        writer.WriteStartElement("secretdata");
+                        writer.WriteString(SecretData);
+                        writer.WriteEndElement();
+
+                        WriteExtraXml(writer);
+                    }
+                }
+        */
+
+        /// <summary>
+        /// Virtual function to write any class specific xml nodes into the writer
+        /// </summary>
+        /// <param name="writer">XmlWriter to write data</param>
+        protected virtual void WriteExtraXml(XmlWriter writer)
+        {
+        }
+
+        #endregion
+
+        #region Utility functions
+
+        /// <summary>
+        /// Create a one-time pad by generating a random block and then taking a hash of that block as many times as needed.
+        /// </summary>
+        /// <param name="length">desired pad length</param>
+        /// <returns>array of bytes conatining random data</returns>
+        protected internal static byte[] CreateOneTimePad(int length)
+        {
+            // There is a MITM vulnerability from using the standard Random call
+            // see https://docs.google.com/document/edit?id=1pf-YCgUnxR4duE8tr-xulE3rJ1Hw-Bm5aMk5tNOGU3E&hl=en
+            // in http://code.google.com/p/winauth/issues/detail?id=2
+            // so we switch out to use RNGCryptoServiceProvider instead of Random
+
+            RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
+
+            byte[] randomblock = new byte[length];
+
+            SHA1 sha1 = SHA1.Create();
+            int i = 0;
+            do
+            {
+                byte[] hashBlock = new byte[128];
+                random.GetBytes(hashBlock);
+
+                byte[] key = sha1.ComputeHash(hashBlock, 0, hashBlock.Length);
+                if (key.Length >= randomblock.Length)
+                {
+                    Array.Copy(key, 0, randomblock, i, randomblock.Length);
+                    break;
+                }
+                Array.Copy(key, 0, randomblock, i, key.Length);
+                i += key.Length;
+            } while (true);
+
+            return randomblock;
+        }
+
+        /// <summary>
+        /// Get the milliseconds since 1/1/70 (same as Java currentTimeMillis)
+        /// </summary>
+        public static long CurrentTime
+        {
+            get
+            {
+                return Convert.ToInt64((DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalMilliseconds);
+            }
+        }
+
+        /// <summary>
+        /// Convert a hex string into a byte array. E.g. "001f406a" -> byte[] {0x00, 0x1f, 0x40, 0x6a}
+        /// </summary>
+        /// <param name="hex">hex string to convert</param>
+        /// <returns>byte[] of hex string</returns>
+        public static byte[] StringToByteArray(string hex)
+        {
+            int len = hex.Length;
+            byte[] bytes = new byte[len / 2];
+            for (int i = 0; i < len; i += 2)
+            {
+                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            }
+            return bytes;
+        }
+
+        /// <summary>
+        /// Convert a byte array into a ascii hex string, e.g. byte[]{0x00,0x1f,0x40,ox6a} -> "001f406a"
+        /// </summary>
+        /// <param name="bytes">byte array to convert</param>
+        /// <returns>string version of byte array</returns>
+        public static string ByteArrayToString(byte[] bytes)
+        {
+            // Use BitConverter, but it sticks dashes in the string
+            return BitConverter.ToString(bytes).Replace("-", string.Empty);
+        }
+
+        /// <summary>
+        /// Decrypt a string sequence using the selected encryption types
+        /// </summary>
+        /// <param name="data">hex coded string sequence to decrypt</param>
+        /// <param name="encryptedTypes">Encryption types</param>
+        /// <param name="password">optional password</param>
+        /// <param name="yubidata">optional yubi data</param>
+        /// <param name="decode"></param>
+        /// <returns>decrypted string sequence</returns>
+        public static string DecryptSequence(string data, PasswordTypes encryptedTypes, string password, YubiKey yubi, bool decode = false)
+        {
+            // check for encrpytion header
+            if (data.Length < ENCRYPTION_HEADER.Length || data.IndexOf(ENCRYPTION_HEADER) != 0)
+            {
+                return DecryptSequenceNoHash(data, encryptedTypes, password, yubi, decode);
+            }
+
+            // extract salt and hash
+            using (var sha = new SHA256Managed())
+            {
+                // jump header
+                int datastart = ENCRYPTION_HEADER.Length;
+                string salt = data.Substring(datastart, Math.Min(SALT_LENGTH * 2, data.Length - datastart));
+                datastart += salt.Length;
+                string hash = data.Substring(datastart, Math.Min(sha.HashSize / 8 * 2, data.Length - datastart));
+                datastart += hash.Length;
+                data = data.Substring(datastart);
+
+                data = DecryptSequenceNoHash(data, encryptedTypes, password, yubi);
+
+                // check the hash
+                byte[] compareplain = StringToByteArray(salt + data);
+                string comparehash = ByteArrayToString(sha.ComputeHash(compareplain));
+                if (string.Compare(comparehash, hash) != 0)
+                {
+                    throw new BadPasswordException();
+                }
+            }
+
+            return data;
+        }
+
+        /// <summary>
+        /// Decrypt a string sequence using the selected encryption types
+        /// </summary>
+        /// <param name="data">hex coded string sequence to decrypt</param>
+        /// <param name="encryptedTypes">Encryption types</param>
+        /// <param name="password">optional password</param>
+        /// <param name="yubidata">optional yubi data</param>
+        /// <param name="decode"></param>
+        /// <returns>decrypted string sequence</returns>
+        private static string DecryptSequenceNoHash(string data, PasswordTypes encryptedTypes, string password, YubiKey yubi, bool decode = false)
+        {
+            try
+            {
+                // reverse order they were encrypted
+                if ((encryptedTypes & PasswordTypes.Machine) != 0)
+                {
+                    // we are going to decrypt with the Windows local machine key
+                    byte[] cipher = Authenticator.StringToByteArray(data);
+                    byte[] plain = ProtectedData.Unprotect(cipher, null, DataProtectionScope.LocalMachine);
+                    if (decode == true)
+                    {
+                        data = Encoding.UTF8.GetString(plain, 0, plain.Length);
+                    }
+                    else
+                    {
+                        data = ByteArrayToString(plain);
+                    }
+                }
+                if ((encryptedTypes & PasswordTypes.User) != 0)
+                {
+                    // we are going to decrypt with the Windows User account key
+                    byte[] cipher = StringToByteArray(data);
+                    byte[] plain = ProtectedData.Unprotect(cipher, null, DataProtectionScope.CurrentUser);
+                    if (decode == true)
+                    {
+                        data = Encoding.UTF8.GetString(plain, 0, plain.Length);
+                    }
+                    else
+                    {
+                        data = ByteArrayToString(plain);
+                    }
+                }
+                if ((encryptedTypes & PasswordTypes.Explicit) != 0)
+                {
+                    // we use an explicit password to encrypt data
+                    if (string.IsNullOrEmpty(password) == true)
+                    {
+                        throw new EncryptedSecretDataException();
+                    }
+                    data = Authenticator.Decrypt(data, password, true);
+                    if (decode == true)
+                    {
+                        byte[] plain = Authenticator.StringToByteArray(data);
+                        data = Encoding.UTF8.GetString(plain, 0, plain.Length);
+                    }
+                }
+                if ((encryptedTypes & PasswordTypes.YubiKeySlot1) != 0 || (encryptedTypes & PasswordTypes.YubiKeySlot2) != 0)
+                {
+                    if (string.IsNullOrEmpty(yubi.Info.Error) == false)
+                    {
+                        throw new BadYubiKeyException("Unable to detect YubiKey");
+                    }
+                    if (yubi.Info.Status.VersionMajor == 0)
+                    {
+                        throw new BadYubiKeyException("Please insert your YubiKey");
+                    }
+                    int slot = ((encryptedTypes & PasswordTypes.YubiKeySlot1) != 0 ? 1 : 2);
+
+                    string seed = data.Substring(0, SALT_LENGTH * 2);
+                    data = data.Substring(seed.Length);
+                    byte[] key = yubi.ChallengeResponse(slot, StringToByteArray(seed));
+
+                    data = Authenticator.Decrypt(data, key);
+                    if (decode == true)
+                    {
+                        byte[] plain = Authenticator.StringToByteArray(data);
+                        data = Encoding.UTF8.GetString(plain, 0, plain.Length);
+                    }
+
+                    yubi.YubiData.Seed = seed;
+                    yubi.YubiData.Data = key;
+                }
+            }
+            catch (EncryptedSecretDataException)
+            {
+                throw;
+            }
+            catch (BadYubiKeyException)
+            {
+                throw;
+            }
+            catch (ChallengeResponseException ex)
+            {
+                throw new BadYubiKeyException("Please check your YubiKey or touch the flashing button", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new BadPasswordException(ex.Message, ex);
+            }
+
+            return data;
+        }
+
+        public static string EncryptSequence(string data, PasswordTypes passwordType, string password, YubiKey yubi)
+        {
+            // get hash of original
+            var random = new RNGCryptoServiceProvider();
+            byte[] saltbytes = new byte[SALT_LENGTH];
+            random.GetBytes(saltbytes);
+            string salt = ByteArrayToString(saltbytes);
+
+            string hash;
+            using (var sha = new SHA256Managed())
+            {
+                byte[] plain = StringToByteArray(salt + data);
+                hash = ByteArrayToString(sha.ComputeHash(plain));
+            }
+
+            if ((passwordType & PasswordTypes.YubiKeySlot1) != 0 || (passwordType & PasswordTypes.YubiKeySlot2) != 0)
+            {
+                if (yubi.YubiData.Length == 0)
+                {
+                    byte[] seed = new byte[SALT_LENGTH];
+                    random = new RNGCryptoServiceProvider();
+                    random.GetBytes(seed);
+
+                    // we encrypt the data using the hash of a random string from the YubiKey
+                    int slot = ((passwordType & PasswordTypes.YubiKeySlot1) != 0 ? 1 : 2);
+                    yubi.YubiData.Data = yubi.ChallengeResponse(slot, seed);
+                    yubi.YubiData.Seed = Authenticator.ByteArrayToString(seed);
+                }
+
+                byte[] key = yubi.YubiData.Data;
+                string encrypted = Encrypt(data, key);
+
+                // test the encryption
+                string decrypted = Decrypt(encrypted, key);
+                if (string.Compare(data, decrypted) != 0)
+                {
+                    throw new InvalidEncryptionException(data, password, encrypted, decrypted);
+                }
+                data = yubi.YubiData.Seed + encrypted;
+            }
+            if ((passwordType & PasswordTypes.Explicit) != 0)
+            {
+                string encrypted = Encrypt(data, password);
+
+                // test the encryption
+                string decrypted = Decrypt(encrypted, password, true);
+                if (string.Compare(data, decrypted) != 0)
+                {
+                    throw new InvalidEncryptionException(data, password, encrypted, decrypted);
+                }
+                data = encrypted;
+            }
+            if ((passwordType & PasswordTypes.User) != 0)
+            {
+                // we encrypt the data using the Windows User account key
+                byte[] plain = StringToByteArray(data);
+                byte[] cipher = ProtectedData.Protect(plain, null, DataProtectionScope.CurrentUser);
+                data = ByteArrayToString(cipher);
+            }
+            if ((passwordType & PasswordTypes.Machine) != 0)
+            {
+                // we encrypt the data using the Local Machine account key
+                byte[] plain = StringToByteArray(data);
+                byte[] cipher = ProtectedData.Protect(plain, null, DataProtectionScope.LocalMachine);
+                data = ByteArrayToString(cipher);
+            }
+
+            // prepend the salt + hash
+            return ENCRYPTION_HEADER + salt + hash + data;
+        }
+
+        /// <summary>
+        /// Encrypt a string with a given key
+        /// </summary>
+        /// <param name="plain">data to encrypt - hex representation of byte array</param>
+        /// <param name="password">key to use to encrypt</param>
+        /// <returns>hex coded encrypted string</returns>
+        public static string Encrypt(string plain, string password)
+        {
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
+
+            // build a new salt
+            RNGCryptoServiceProvider rg = new RNGCryptoServiceProvider();
+            byte[] saltbytes = new byte[SALT_LENGTH];
+            rg.GetBytes(saltbytes);
+            string salt = Authenticator.ByteArrayToString(saltbytes);
+
+            // build our PBKDF2 key
 #if NETCF
 			PBKDF2 kg = new PBKDF2(passwordBytes, saltbytes, PBKDF2_ITERATIONS);
 #else
-			Rfc2898DeriveBytes kg = new Rfc2898DeriveBytes(passwordBytes, saltbytes, PBKDF2_ITERATIONS);
+            Rfc2898DeriveBytes kg = new Rfc2898DeriveBytes(passwordBytes, saltbytes, PBKDF2_ITERATIONS);
 #endif
-			byte[] key = kg.GetBytes(PBKDF2_KEYSIZE);
+            byte[] key = kg.GetBytes(PBKDF2_KEYSIZE);
 
-			return salt + Encrypt(plain, key);
-		}
+            return salt + Encrypt(plain, key);
+        }
 
-		/// <summary>
-		/// Encrypt a string with a byte array key
-		/// </summary>
-		/// <param name="plain">data to encrypt - hex representation of byte array</param>
-		/// <param name="passwordBytes">key to use to encrypt</param>
-		/// <returns>hex coded encrypted string</returns>
-		public static string Encrypt(string plain, byte[] key)
-		{
-			byte[] inBytes = Authenticator.StringToByteArray(plain);
+        /// <summary>
+        /// Encrypt a string with a byte array key
+        /// </summary>
+        /// <param name="plain">data to encrypt - hex representation of byte array</param>
+        /// <param name="passwordBytes">key to use to encrypt</param>
+        /// <returns>hex coded encrypted string</returns>
+        public static string Encrypt(string plain, byte[] key)
+        {
+            byte[] inBytes = Authenticator.StringToByteArray(plain);
 
-			// get our cipher
-			BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
-			cipher.Init(true, new KeyParameter(key));
+            // get our cipher
+            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
+            cipher.Init(true, new KeyParameter(key));
 
-			// encrypt data
-			int osize = cipher.GetOutputSize(inBytes.Length);
-			byte[] outBytes = new byte[osize];
-			int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
-			olen += cipher.DoFinal(outBytes, olen);
-			if (olen < osize)
-			{
-				byte[] t = new byte[olen];
-				Array.Copy(outBytes, 0, t, 0, olen);
-				outBytes = t;
-			}
+            // encrypt data
+            int osize = cipher.GetOutputSize(inBytes.Length);
+            byte[] outBytes = new byte[osize];
+            int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
+            olen += cipher.DoFinal(outBytes, olen);
+            if (olen < osize)
+            {
+                byte[] t = new byte[olen];
+                Array.Copy(outBytes, 0, t, 0, olen);
+                outBytes = t;
+            }
 
-			// return encoded byte->hex string
-			return Authenticator.ByteArrayToString(outBytes);
-		}
+            // return encoded byte->hex string
+            return Authenticator.ByteArrayToString(outBytes);
+        }
 
-		/// <summary>
-		/// Decrypt a hex-coded string using our MD5 or PBKDF2 generated key
-		/// </summary>
-		/// <param name="data">data string to be decrypted</param>
-		/// <param name="key">decryption key</param>
-		/// <param name="PBKDF2">flag to indicate we are using PBKDF2 to generate derived key</param>
-		/// <returns>hex coded decrypted string</returns>
-		public static string Decrypt(string data, string password, bool PBKDF2)
-		{
-			byte[] key;
-			byte[] saltBytes = Authenticator.StringToByteArray(data.Substring(0, SALT_LENGTH * 2));
+        /// <summary>
+        /// Decrypt a hex-coded string using our MD5 or PBKDF2 generated key
+        /// </summary>
+        /// <param name="data">data string to be decrypted</param>
+        /// <param name="key">decryption key</param>
+        /// <param name="PBKDF2">flag to indicate we are using PBKDF2 to generate derived key</param>
+        /// <returns>hex coded decrypted string</returns>
+        public static string Decrypt(string data, string password, bool PBKDF2)
+        {
+            byte[] key;
+            byte[] saltBytes = Authenticator.StringToByteArray(data.Substring(0, SALT_LENGTH * 2));
 
-			if (PBKDF2 == true)
-			{
-				// extract the salt from the data
-				byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
+            if (PBKDF2 == true)
+            {
+                // extract the salt from the data
+                byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
 
-				// build our PBKDF2 key
+                // build our PBKDF2 key
 #if NETCF
 			PBKDF2 kg = new PBKDF2(passwordBytes, saltbytes, 2000);
 #else
-				Rfc2898DeriveBytes kg = new Rfc2898DeriveBytes(passwordBytes, saltBytes, PBKDF2_ITERATIONS);
+                Rfc2898DeriveBytes kg = new Rfc2898DeriveBytes(passwordBytes, saltBytes, PBKDF2_ITERATIONS);
 #endif
-				key = kg.GetBytes(PBKDF2_KEYSIZE);
-			}
-			else
-			{
-				// extract the salt from the data
-				byte[] passwordBytes = Encoding.Default.GetBytes(password);
-				key = new byte[saltBytes.Length + passwordBytes.Length];
-				Array.Copy(saltBytes, key, saltBytes.Length);
-				Array.Copy(passwordBytes, 0, key, saltBytes.Length, passwordBytes.Length);
-				// build out combined key
-				MD5 md5 = MD5.Create();
-				key = md5.ComputeHash(key);
-			}
+                key = kg.GetBytes(PBKDF2_KEYSIZE);
+            }
+            else
+            {
+                // extract the salt from the data
+                byte[] passwordBytes = Encoding.Default.GetBytes(password);
+                key = new byte[saltBytes.Length + passwordBytes.Length];
+                Array.Copy(saltBytes, key, saltBytes.Length);
+                Array.Copy(passwordBytes, 0, key, saltBytes.Length, passwordBytes.Length);
+                // build out combined key
+                MD5 md5 = MD5.Create();
+                key = md5.ComputeHash(key);
+            }
 
-			// extract the actual data to be decrypted
-			byte[] inBytes = Authenticator.StringToByteArray(data.Substring(SALT_LENGTH * 2));
+            // extract the actual data to be decrypted
+            byte[] inBytes = Authenticator.StringToByteArray(data.Substring(SALT_LENGTH * 2));
 
-			// get cipher
-			BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
-			cipher.Init(false, new KeyParameter(key));
+            // get cipher
+            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
+            cipher.Init(false, new KeyParameter(key));
 
-			// decrypt the data
-			int osize = cipher.GetOutputSize(inBytes.Length);
-			byte[] outBytes = new byte[osize];
-			try
-			{
-				int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
-				olen += cipher.DoFinal(outBytes, olen);
-				if (olen < osize)
-				{
-					byte[] t = new byte[olen];
-					Array.Copy(outBytes, 0, t, 0, olen);
-					outBytes = t;
-				}
-			}
-			catch (Exception )
-			{
-				// an exception is due to bad password
-				throw new BadPasswordException();
-			}
+            // decrypt the data
+            int osize = cipher.GetOutputSize(inBytes.Length);
+            byte[] outBytes = new byte[osize];
+            try
+            {
+                int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
+                olen += cipher.DoFinal(outBytes, olen);
+                if (olen < osize)
+                {
+                    byte[] t = new byte[olen];
+                    Array.Copy(outBytes, 0, t, 0, olen);
+                    outBytes = t;
+                }
+            }
+            catch (Exception)
+            {
+                // an exception is due to bad password
+                throw new BadPasswordException();
+            }
 
-			// return encoded string
-			return Authenticator.ByteArrayToString(outBytes);
-		}
+            // return encoded string
+            return Authenticator.ByteArrayToString(outBytes);
+        }
 
-		/// <summary>
-		/// Decrypt a hex-encoded string with a byte array key
-		/// </summary>
-		/// <param name="data">hex-encoded string</param>
-		/// <param name="key">key for decryption</param>
-		/// <returns>hex-encoded plain text</returns>
-		public static string Decrypt(string data, byte[] key)
-		{
-			// the actual data to be decrypted
-			byte[] inBytes = Authenticator.StringToByteArray(data);
+        /// <summary>
+        /// Decrypt a hex-encoded string with a byte array key
+        /// </summary>
+        /// <param name="data">hex-encoded string</param>
+        /// <param name="key">key for decryption</param>
+        /// <returns>hex-encoded plain text</returns>
+        public static string Decrypt(string data, byte[] key)
+        {
+            // the actual data to be decrypted
+            byte[] inBytes = Authenticator.StringToByteArray(data);
 
-			// get cipher
-			BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
-			cipher.Init(false, new KeyParameter(key));
+            // get cipher
+            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new BlowfishEngine(), new ISO10126d2Padding());
+            cipher.Init(false, new KeyParameter(key));
 
-			// decrypt the data
-			int osize = cipher.GetOutputSize(inBytes.Length);
-			byte[] outBytes = new byte[osize];
-			try
-			{
-				int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
-				olen += cipher.DoFinal(outBytes, olen);
-				if (olen < osize)
-				{
-					byte[] t = new byte[olen];
-					Array.Copy(outBytes, 0, t, 0, olen);
-					outBytes = t;
-				}
-			}
-			catch (Exception)
-			{
-				// an exception is due to bad password
-				throw new BadPasswordException();
-			}
+            // decrypt the data
+            int osize = cipher.GetOutputSize(inBytes.Length);
+            byte[] outBytes = new byte[osize];
+            try
+            {
+                int olen = cipher.ProcessBytes(inBytes, 0, inBytes.Length, outBytes, 0);
+                olen += cipher.DoFinal(outBytes, olen);
+                if (olen < osize)
+                {
+                    byte[] t = new byte[olen];
+                    Array.Copy(outBytes, 0, t, 0, olen);
+                    outBytes = t;
+                }
+            }
+            catch (Exception)
+            {
+                // an exception is due to bad password
+                throw new BadPasswordException();
+            }
 
-			// return encoded string
-			return Authenticator.ByteArrayToString(outBytes);
-		}
+            // return encoded string
+            return Authenticator.ByteArrayToString(outBytes);
+        }
 
-		/// <summary>
-		/// Wrapped TryParse for compatibility with NETCF35 to simulate long.TryParse
-		/// </summary>
-		/// <param name="s">string of value to parse</param>
-		/// <param name="val">out long value</param>
-		/// <returns>true if value was parsed</returns>
-		protected internal static bool LongTryParse(string s, out long val)
-		{
+        /// <summary>
+        /// Wrapped TryParse for compatibility with NETCF35 to simulate long.TryParse
+        /// </summary>
+        /// <param name="s">string of value to parse</param>
+        /// <param name="val">out long value</param>
+        /// <returns>true if value was parsed</returns>
+        protected internal static bool LongTryParse(string s, out long val)
+        {
 #if NETCF
 			try
 			{
@@ -1289,25 +1289,25 @@ namespace WinAuth
 				return false;
 			}
 #else
-			return long.TryParse(s, out val);
+            return long.TryParse(s, out val);
 #endif
-		}
+        }
 
-#endregion
+        #endregion
 
-#region ICloneable
+        #region ICloneable
 
-		/// <summary>
-		/// Clone the current object
-		/// </summary>
-		/// <returns>return clone</returns>
-		public object Clone()
-		{
-			// we only need to do shallow copy
-			return this.MemberwiseClone();
-		}
+        /// <summary>
+        /// Clone the current object
+        /// </summary>
+        /// <returns>return clone</returns>
+        public object Clone()
+        {
+            // we only need to do shallow copy
+            return this.MemberwiseClone();
+        }
 
-#endregion
+        #endregion
 
 #if NETCF
 		/// <summary>
@@ -1455,5 +1455,5 @@ namespace WinAuth
 
 #endif
 
-	}
+    }
 }

--- a/Authenticator/AuthenticatorException.cs
+++ b/Authenticator/AuthenticatorException.cs
@@ -100,9 +100,9 @@ namespace WinAuth
 	/// <summary>
 	/// Config has been encryoted and we need a key
 	/// </summary>
-	public class EncrpytedSecretDataException : AuthenticatorException
+	public class EncryptedSecretDataException : AuthenticatorException
 	{
-		public EncrpytedSecretDataException() : base() { }
+		public EncryptedSecretDataException() : base() { }
 	}
 
 	/// <summary>

--- a/Authenticator/AuthenticatorException.cs
+++ b/Authenticator/AuthenticatorException.cs
@@ -57,6 +57,14 @@ namespace WinAuth
 		public InvalidConfigDataException() : base() {}
 	}
 
+    /// <summary>
+    /// Exception for invalid HMAC algorithm configuration
+    /// </summary>
+    public class InvalidHMACAlgorithmException : AuthenticatorException
+    {
+        public InvalidHMACAlgorithmException() : base() {}
+    }
+
 	/// <summary>
 	/// Exception for invalid user decryption
 	/// </summary>
@@ -98,7 +106,7 @@ namespace WinAuth
 	}
 
 	/// <summary>
-	/// Config has been encryoted and we need a key
+	/// Config has been encrypted and we need a key
 	/// </summary>
 	public class EncryptedSecretDataException : AuthenticatorException
 	{

--- a/Authenticator/BattleNetAuthenticator.cs
+++ b/Authenticator/BattleNetAuthenticator.cs
@@ -462,7 +462,7 @@ namespace WinAuth
 			// check if data is protected
 			if (this.SecretKey == null && this.EncryptedData != null)
 			{
-				throw new EncrpytedSecretDataException();
+				throw new EncryptedSecretDataException();
 			}
 
 			// don't retry for 5 minutes

--- a/Authenticator/GoogleAuthenticator.cs
+++ b/Authenticator/GoogleAuthenticator.cs
@@ -92,9 +92,10 @@ namespace WinAuth
 
     /// <summary>
     /// Enroll the authenticator with the server.
-    public void Enroll(string b32key)
+    public void Enroll(string b32key, HMACTypes hmacType = HMACTypes.SHA1)
     {
       SecretKey = Base32.getInstance().Decode(b32key);
+      HMACType = hmacType;
       Sync();
     }
 

--- a/Authenticator/GoogleAuthenticator.cs
+++ b/Authenticator/GoogleAuthenticator.cs
@@ -106,7 +106,7 @@ namespace WinAuth
 			// check if data is protected
 			if (this.SecretKey == null && this.EncryptedData != null)
 			{
-				throw new EncrpytedSecretDataException();
+				throw new EncryptedSecretDataException();
 			}
 
 			// don't retry for 5 minutes

--- a/Authenticator/SteamAuthenticator.cs
+++ b/Authenticator/SteamAuthenticator.cs
@@ -671,7 +671,7 @@ namespace WinAuth
 			// check if data is protected
 			if (this.SecretKey == null && this.EncryptedData != null)
 			{
-				throw new EncrpytedSecretDataException();
+				throw new EncryptedSecretDataException();
 			}
 
 			// don't retry for 5 minutes

--- a/Authenticator/TrionAuthenticator.cs
+++ b/Authenticator/TrionAuthenticator.cs
@@ -264,7 +264,7 @@ namespace WinAuth
 			// check if data is protected
 			if (this.SecretKey == null && this.EncryptedData != null)
 			{
-				throw new EncrpytedSecretDataException();
+				throw new EncryptedSecretDataException();
 			}
 
 			// don't retry for 5 minutes

--- a/WinAuth/AddAuthenticator.cs
+++ b/WinAuth/AddAuthenticator.cs
@@ -80,6 +80,7 @@ namespace WinAuth
         {
             nameField.Text = this.Authenticator.Name;
             codeField.SecretMode = true;
+            cmbHMACType.SelectedIndex = 0;
         }
 
         /// <summary>
@@ -318,6 +319,20 @@ namespace WinAuth
             this.Authenticator.Name = nameField.Text;
 
             int digits = (this.Authenticator.AuthenticatorData != null ? this.Authenticator.AuthenticatorData.CodeDigits : GoogleAuthenticator.DEFAULT_CODE_DIGITS);
+            HMACTypes hmacType = HMACTypes.SHA1;
+
+            switch (cmbHMACType.SelectedIndex)
+            {
+                case 0:
+                    hmacType = HMACTypes.SHA1;
+                    break;
+                case 1:
+                    hmacType = HMACTypes.SHA256;
+                    break;
+                case 2:
+                    hmacType = HMACTypes.SHA512;
+                    break;
+            }
 
             string authtype = timeBasedRadio.Checked == true ? TOTP : HOTP;
 
@@ -419,11 +434,29 @@ namespace WinAuth
                     label = issuer + (string.IsNullOrEmpty(label) == false ? " (" + label + ")" : string.Empty);
                 }
                 serial = qs["serial"];
-
                 if (string.IsNullOrEmpty(label) == false)
                 {
                     this.Authenticator.Name = this.nameField.Text = label;
                 }
+                if (qs["algorithm"] != null)
+                {
+                    switch (qs["algorithm"].ToUpper())
+                    {
+                        case "SHA1":
+                            cmbHMACType.SelectedIndex = 0;
+                            hmacType = HMACTypes.SHA1;
+                            break;
+                        case "SHA256":
+                            cmbHMACType.SelectedIndex = 1;
+                            hmacType = HMACTypes.SHA256;
+                            break;
+                        case "SHA512":
+                            cmbHMACType.SelectedIndex = 2;
+                            hmacType = HMACTypes.SHA512;
+                            break;
+                    }
+                }
+
             }
 
             // just get the hex chars
@@ -472,7 +505,7 @@ namespace WinAuth
                     else
                     {
                         auth = new GoogleAuthenticator();
-                        ((GoogleAuthenticator)auth).Enroll(privatekey);
+                        ((GoogleAuthenticator)auth).Enroll(privatekey, hmacType);
                     }
                     timer.Enabled = true;
                     codeProgress.Visible = true;

--- a/WinAuth/AddAuthenticator.cs
+++ b/WinAuth/AddAuthenticator.cs
@@ -36,498 +36,498 @@ using ZXing;
 
 namespace WinAuth
 {
-	/// <summary>
-	/// Form class for create a new Battle.net authenticator
-	/// </summary>
-	public partial class AddAuthenticator : ResourceForm
-	{
-		/// <summary>
-		/// HOTP string
-		/// </summary>
-		private const string HOTP = "hotp";
+    /// <summary>
+    /// Form class for create a new Battle.net authenticator
+    /// </summary>
+    public partial class AddAuthenticator : ResourceForm
+    {
+        /// <summary>
+        /// HOTP string
+        /// </summary>
+        private const string HOTP = "hotp";
 
-		/// <summary>
-		/// TOTP string
-		/// </summary>
-		private const string TOTP = "totp";
+        /// <summary>
+        /// TOTP string
+        /// </summary>
+        private const string TOTP = "totp";
 
-		/// <summary>
-		/// Form instantiation
-		/// </summary>
-		public AddAuthenticator()
-		{
-			InitializeComponent();
-		}
+        /// <summary>
+        /// Form instantiation
+        /// </summary>
+        public AddAuthenticator()
+        {
+            InitializeComponent();
+        }
 
-		/// <summary>
-		/// Current authenticator
-		/// </summary>
-		public WinAuthAuthenticator Authenticator { get; set; }
+        /// <summary>
+        /// Current authenticator
+        /// </summary>
+        public WinAuthAuthenticator Authenticator { get; set; }
 
-		/// <summary>
-		/// If we have already warned about sync error
-		/// </summary>
-		private bool SyncErrorWarned;
+        /// <summary>
+        /// If we have already warned about sync error
+        /// </summary>
+        private bool SyncErrorWarned;
 
-#region Form Events
+        #region Form Events
 
-		/// <summary>
-		/// Load the form
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void AddAuthenticator_Load(object sender, EventArgs e)
-		{
-			nameField.Text = this.Authenticator.Name;
-			codeField.SecretMode = true;
-		}
+        /// <summary>
+        /// Load the form
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void AddAuthenticator_Load(object sender, EventArgs e)
+        {
+            nameField.Text = this.Authenticator.Name;
+            codeField.SecretMode = true;
+        }
 
-		/// <summary>
-		/// Timer tick to show code
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void timer_Tick(object sender, EventArgs e)
-		{
-			if (this.Authenticator.AuthenticatorData != null && !(this.Authenticator.AuthenticatorData is HOTPAuthenticator) && codeProgress.Visible == true)
-			{
-				int time = (int)(this.Authenticator.AuthenticatorData.ServerTime / 1000L) % 30;
-				codeProgress.Value = time + 1;
-				if (time == 0)
-				{
-					codeField.Text = this.Authenticator.AuthenticatorData.CurrentCode;
-				}
-			}
-		}
+        /// <summary>
+        /// Timer tick to show code
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void timer_Tick(object sender, EventArgs e)
+        {
+            if (this.Authenticator.AuthenticatorData != null && !(this.Authenticator.AuthenticatorData is HOTPAuthenticator) && codeProgress.Visible == true)
+            {
+                int time = (int)(this.Authenticator.AuthenticatorData.ServerTime / 1000L) % 30;
+                codeProgress.Value = time + 1;
+                if (time == 0)
+                {
+                    codeField.Text = this.Authenticator.AuthenticatorData.CurrentCode;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Handle cancel button with warning
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void cancelButton_Click(object sender, EventArgs e)
-		{
-			if (this.Authenticator.AuthenticatorData != null)
-			{
-				DialogResult result = WinAuthForm.ConfirmDialog(this.Owner,
-					"WARNING: Your authenticator has not been saved." + Environment.NewLine + Environment.NewLine
-					+ "If you have added this authenticator to your online account, you will not be able to login in the future, and you need to click YES to save it." + Environment.NewLine + Environment.NewLine
-					+ "Do you want to save this authenticator?", MessageBoxButtons.YesNoCancel);
-				if (result == System.Windows.Forms.DialogResult.Yes)
-				{
-					this.DialogResult = System.Windows.Forms.DialogResult.OK;
-					return;
-				}
-				else if (result == System.Windows.Forms.DialogResult.Cancel)
-				{
-					this.DialogResult = System.Windows.Forms.DialogResult.None;
-					return;
-				}
-			}
-		}
+        /// <summary>
+        /// Handle cancel button with warning
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void cancelButton_Click(object sender, EventArgs e)
+        {
+            if (this.Authenticator.AuthenticatorData != null)
+            {
+                DialogResult result = WinAuthForm.ConfirmDialog(this.Owner,
+                    "WARNING: Your authenticator has not been saved." + Environment.NewLine + Environment.NewLine
+                    + "If you have added this authenticator to your online account, you will not be able to login in the future, and you need to click YES to save it." + Environment.NewLine + Environment.NewLine
+                    + "Do you want to save this authenticator?", MessageBoxButtons.YesNoCancel);
+                if (result == System.Windows.Forms.DialogResult.Yes)
+                {
+                    this.DialogResult = System.Windows.Forms.DialogResult.OK;
+                    return;
+                }
+                else if (result == System.Windows.Forms.DialogResult.Cancel)
+                {
+                    this.DialogResult = System.Windows.Forms.DialogResult.None;
+                    return;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Click the OK button to verify and add the authenticator
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void okButton_Click(object sender, EventArgs e)
-		{
-			string privatekey = this.secretCodeField.Text.Trim();
-			if (privatekey.Length == 0)
-			{
-				WinAuthForm.ErrorDialog(this.Owner, "Please enter the Secret Code");
-				this.DialogResult = System.Windows.Forms.DialogResult.None;
-				return;
-			}
-			bool first = (this.Authenticator.AuthenticatorData == null);
-			if (verifyAuthenticator(privatekey) == false)
-			{
-				this.DialogResult = System.Windows.Forms.DialogResult.None;
-				return;
-			}
-			if (first == true)
-			{
-				this.DialogResult = System.Windows.Forms.DialogResult.None;
-				return;
-			}
+        /// <summary>
+        /// Click the OK button to verify and add the authenticator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void okButton_Click(object sender, EventArgs e)
+        {
+            string privatekey = this.secretCodeField.Text.Trim();
+            if (privatekey.Length == 0)
+            {
+                WinAuthForm.ErrorDialog(this.Owner, "Please enter the Secret Code");
+                this.DialogResult = System.Windows.Forms.DialogResult.None;
+                return;
+            }
+            bool first = (this.Authenticator.AuthenticatorData == null);
+            if (verifyAuthenticator(privatekey) == false)
+            {
+                this.DialogResult = System.Windows.Forms.DialogResult.None;
+                return;
+            }
+            if (first == true)
+            {
+                this.DialogResult = System.Windows.Forms.DialogResult.None;
+                return;
+            }
 
-			// if this is a htop we reduce the counter because we are going to immediate get the code and increment
-			if (this.Authenticator.AuthenticatorData is HOTPAuthenticator)
-			{
-				((HOTPAuthenticator)this.Authenticator.AuthenticatorData).Counter--;
-			}
-		}
+            // if this is a htop we reduce the counter because we are going to immediate get the code and increment
+            if (this.Authenticator.AuthenticatorData is HOTPAuthenticator)
+            {
+                ((HOTPAuthenticator)this.Authenticator.AuthenticatorData).Counter--;
+            }
+        }
 
-		/// <summary>
-		/// Click verify button to load and check code
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void verifyButton_Click(object sender, EventArgs e)
-		{
-			string privatekey = this.secretCodeField.Text.Trim();
-			if (privatekey.Length == 0)
-			{
-				WinAuthForm.ErrorDialog(this.Owner, "Please enter the Secret Code");
-				return;
-			}
-			verifyAuthenticator(privatekey);
-		}
+        /// <summary>
+        /// Click verify button to load and check code
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void verifyButton_Click(object sender, EventArgs e)
+        {
+            string privatekey = this.secretCodeField.Text.Trim();
+            if (privatekey.Length == 0)
+            {
+                WinAuthForm.ErrorDialog(this.Owner, "Please enter the Secret Code");
+                return;
+            }
+            verifyAuthenticator(privatekey);
+        }
 
-		/// <summary>
-		/// Select the time-based authenticator
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void timeBasedRadio_CheckedChanged(object sender, EventArgs e)
-		{
-			counterBasedRadio.Checked = !timeBasedRadio.Checked;
-			if (timeBasedRadio.Checked == true)
-			{
-				timeBasedPanel.Visible = true;
-				counterBasedPanel.Visible = false;
-			}
-		}
+        /// <summary>
+        /// Select the time-based authenticator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void timeBasedRadio_CheckedChanged(object sender, EventArgs e)
+        {
+            counterBasedRadio.Checked = !timeBasedRadio.Checked;
+            if (timeBasedRadio.Checked == true)
+            {
+                timeBasedPanel.Visible = true;
+                counterBasedPanel.Visible = false;
+            }
+        }
 
-		/// <summary>
-		/// Select the counter-based authenticator
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void counterBasedRadio_CheckedChanged(object sender, EventArgs e)
-		{
-			timeBasedRadio.Checked = !counterBasedRadio.Checked;
-			if (counterBasedRadio.Checked == true)
-			{
-				counterBasedPanel.Visible = true;
-				timeBasedPanel.Visible = false;
-			}
-		}
+        /// <summary>
+        /// Select the counter-based authenticator
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void counterBasedRadio_CheckedChanged(object sender, EventArgs e)
+        {
+            timeBasedRadio.Checked = !counterBasedRadio.Checked;
+            if (counterBasedRadio.Checked == true)
+            {
+                counterBasedPanel.Visible = true;
+                timeBasedPanel.Visible = false;
+            }
+        }
 
-		/// <summary>
-		/// Click the button to convert any secret code
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void secretCodeButton_Click(object sender, EventArgs e)
-		{
-			Uri uri;
-			Match match;
+        /// <summary>
+        /// Click the button to convert any secret code
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void secretCodeButton_Click(object sender, EventArgs e)
+        {
+            Uri uri;
+            Match match;
 
-			if (Regex.IsMatch(secretCodeField.Text, "https?://.*") == true && Uri.TryCreate(secretCodeField.Text, UriKind.Absolute, out uri) == true)
-			{
-				try
-				{
-					var request = (HttpWebRequest)WebRequest.Create(uri);
-					request.AllowAutoRedirect = true;
-					request.Timeout = 20000;
-					request.UserAgent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
-					using (var response = (HttpWebResponse)request.GetResponse())
-					{
-						if (response.StatusCode == HttpStatusCode.OK && response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
-						{
-							using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(response.GetResponseStream()))
-							{
-								IBarcodeReader reader = new BarcodeReader();
-								var result = reader.Decode(bitmap);
-								if (result != null && string.IsNullOrEmpty(result.Text) == false)
-								{
-									secretCodeField.Text = HttpUtility.UrlDecode(result.Text);
-								}
-							}
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					WinAuthForm.ErrorDialog(this.Owner, "Cannot load QR code image from " + secretCodeField.Text, ex);
-					return;
-				}
-			}
+            if (Regex.IsMatch(secretCodeField.Text, "https?://.*") == true && Uri.TryCreate(secretCodeField.Text, UriKind.Absolute, out uri) == true)
+            {
+                try
+                {
+                    var request = (HttpWebRequest)WebRequest.Create(uri);
+                    request.AllowAutoRedirect = true;
+                    request.Timeout = 20000;
+                    request.UserAgent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
+                    using (var response = (HttpWebResponse)request.GetResponse())
+                    {
+                        if (response.StatusCode == HttpStatusCode.OK && response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(response.GetResponseStream()))
+                            {
+                                IBarcodeReader reader = new BarcodeReader();
+                                var result = reader.Decode(bitmap);
+                                if (result != null && string.IsNullOrEmpty(result.Text) == false)
+                                {
+                                    secretCodeField.Text = HttpUtility.UrlDecode(result.Text);
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WinAuthForm.ErrorDialog(this.Owner, "Cannot load QR code image from " + secretCodeField.Text, ex);
+                    return;
+                }
+            }
 
-			match = Regex.Match(secretCodeField.Text, @"otpauth://([^/]+)/([^?]+)\?(.*)", RegexOptions.IgnoreCase);
-			if (match.Success == true)
-			{
-				string authtype = match.Groups[1].Value.ToLower();
-				string label = match.Groups[2].Value;
+            match = Regex.Match(secretCodeField.Text, @"otpauth://([^/]+)/([^?]+)\?(.*)", RegexOptions.IgnoreCase);
+            if (match.Success == true)
+            {
+                string authtype = match.Groups[1].Value.ToLower();
+                string label = match.Groups[2].Value;
 
-				if (authtype == HOTP)
-				{
-					counterBasedRadio.Checked = true;
+                if (authtype == HOTP)
+                {
+                    counterBasedRadio.Checked = true;
 
-					NameValueCollection qs = WinAuthHelper.ParseQueryString(match.Groups[3].Value);
-					if (qs["counter"] != null)
-					{
-						long counter;
-						if (long.TryParse(qs["counter"], out counter) == true)
-						{
-							counterField.Text = counter.ToString();
-						}
-					}
+                    NameValueCollection qs = WinAuthHelper.ParseQueryString(match.Groups[3].Value);
+                    if (qs["counter"] != null)
+                    {
+                        long counter;
+                        if (long.TryParse(qs["counter"], out counter) == true)
+                        {
+                            counterField.Text = counter.ToString();
+                        }
+                    }
 
-					string issuer = qs["issuer"];
-					if (string.IsNullOrEmpty(issuer) == false)
-					{
-						label = issuer + (string.IsNullOrEmpty(label) == false ? " (" + label + ")" : string.Empty);
-					}
+                    string issuer = qs["issuer"];
+                    if (string.IsNullOrEmpty(issuer) == false)
+                    {
+                        label = issuer + (string.IsNullOrEmpty(label) == false ? " (" + label + ")" : string.Empty);
+                    }
 
-					this.nameField.Text = label;
-				}
-				else if (authtype == TOTP)
-				{
-					timeBasedRadio.Checked = true;
-					counterField.Text = string.Empty;
-				}
-			}
-		}
+                    this.nameField.Text = label;
+                }
+                else if (authtype == TOTP)
+                {
+                    timeBasedRadio.Checked = true;
+                    counterField.Text = string.Empty;
+                }
+            }
+        }
 
-#endregion
+        #endregion
 
-#region Private methods
+        #region Private methods
 
-		/// <summary>
-		/// Check if a filename is valid and such a file exists
-		/// </summary>
-		/// <param name="filename">filename to check</param>
-		/// <returns>true if valid and exists</returns>
-		private bool IsValidFile(string filename)
-		{
-			try
-			{
-				// check path is valid
-				new FileInfo(filename);
-				return File.Exists(filename);
-			}
-			catch (Exception) { }
+        /// <summary>
+        /// Check if a filename is valid and such a file exists
+        /// </summary>
+        /// <param name="filename">filename to check</param>
+        /// <returns>true if valid and exists</returns>
+        private bool IsValidFile(string filename)
+        {
+            try
+            {
+                // check path is valid
+                new FileInfo(filename);
+                return File.Exists(filename);
+            }
+            catch (Exception) { }
 
-			return false;
-		}
+            return false;
+        }
 
-		/// <summary>
-		/// Verify and create the authenticator if needed
-		/// </summary>
-		/// <returns>true is successful</returns>
-		private bool verifyAuthenticator(string privatekey)
-		{
-			if (string.IsNullOrEmpty(privatekey) == true)
-			{
-				return false;
-			}
+        /// <summary>
+        /// Verify and create the authenticator if needed
+        /// </summary>
+        /// <returns>true is successful</returns>
+        private bool verifyAuthenticator(string privatekey)
+        {
+            if (string.IsNullOrEmpty(privatekey) == true)
+            {
+                return false;
+            }
 
-			this.Authenticator.Name = nameField.Text;
+            this.Authenticator.Name = nameField.Text;
 
-			int digits = (this.Authenticator.AuthenticatorData != null ? this.Authenticator.AuthenticatorData.CodeDigits : GoogleAuthenticator.DEFAULT_CODE_DIGITS);
+            int digits = (this.Authenticator.AuthenticatorData != null ? this.Authenticator.AuthenticatorData.CodeDigits : GoogleAuthenticator.DEFAULT_CODE_DIGITS);
 
-			string authtype = timeBasedRadio.Checked == true ? TOTP : HOTP;
+            string authtype = timeBasedRadio.Checked == true ? TOTP : HOTP;
 
-			long counter = 0;
+            long counter = 0;
 
-			// if this is a URL, pull it down
-			Uri uri;
-			Match match;
-			if (Regex.IsMatch(privatekey, "https?://.*") == true && Uri.TryCreate(privatekey, UriKind.Absolute, out uri) == true)
-			{
-				try
-				{
-					var request = (HttpWebRequest)WebRequest.Create(uri);
-					request.AllowAutoRedirect = true;
-					request.Timeout = 20000;
-					request.UserAgent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
-					using (var response = (HttpWebResponse)request.GetResponse())
-					{
-						if (response.StatusCode == HttpStatusCode.OK && response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
-						{
-							using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(response.GetResponseStream()))
-							{
-								IBarcodeReader reader = new BarcodeReader();
-								var result = reader.Decode(bitmap);
-								if (result != null)
-								{
-									privatekey = HttpUtility.UrlDecode(result.Text);
-								}
-							}
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					WinAuthForm.ErrorDialog(this.Owner, "Cannot load QR code image from " + privatekey, ex);
-					return false;
-				}
-			}
-			else if ((match = Regex.Match(privatekey, @"data:image/([^;]+);base64,(.*)", RegexOptions.IgnoreCase)).Success == true)
-			{
-				byte[] imagedata = Convert.FromBase64String(match.Groups[2].Value);
-				using (MemoryStream ms = new MemoryStream(imagedata))
-				{
-					using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(ms))
-					{
-						IBarcodeReader reader = new BarcodeReader();
-						var result = reader.Decode(bitmap);
-						if (result != null)
-						{
-							privatekey = HttpUtility.UrlDecode(result.Text);
-						}
-					}
-				}
-			}
-			else if (IsValidFile(privatekey) == true)
-			{
-				// assume this is the image file
-				using (Bitmap bitmap = (Bitmap)Bitmap.FromFile(privatekey))
-				{
-					IBarcodeReader reader = new BarcodeReader();
-					var result = reader.Decode(bitmap);
-					if (result != null)
-					{
-						privatekey = result.Text;
-					}
-				}
-			}
+            // if this is a URL, pull it down
+            Uri uri;
+            Match match;
+            if (Regex.IsMatch(privatekey, "https?://.*") == true && Uri.TryCreate(privatekey, UriKind.Absolute, out uri) == true)
+            {
+                try
+                {
+                    var request = (HttpWebRequest)WebRequest.Create(uri);
+                    request.AllowAutoRedirect = true;
+                    request.Timeout = 20000;
+                    request.UserAgent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
+                    using (var response = (HttpWebResponse)request.GetResponse())
+                    {
+                        if (response.StatusCode == HttpStatusCode.OK && response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(response.GetResponseStream()))
+                            {
+                                IBarcodeReader reader = new BarcodeReader();
+                                var result = reader.Decode(bitmap);
+                                if (result != null)
+                                {
+                                    privatekey = HttpUtility.UrlDecode(result.Text);
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WinAuthForm.ErrorDialog(this.Owner, "Cannot load QR code image from " + privatekey, ex);
+                    return false;
+                }
+            }
+            else if ((match = Regex.Match(privatekey, @"data:image/([^;]+);base64,(.*)", RegexOptions.IgnoreCase)).Success == true)
+            {
+                byte[] imagedata = Convert.FromBase64String(match.Groups[2].Value);
+                using (MemoryStream ms = new MemoryStream(imagedata))
+                {
+                    using (Bitmap bitmap = (Bitmap)Bitmap.FromStream(ms))
+                    {
+                        IBarcodeReader reader = new BarcodeReader();
+                        var result = reader.Decode(bitmap);
+                        if (result != null)
+                        {
+                            privatekey = HttpUtility.UrlDecode(result.Text);
+                        }
+                    }
+                }
+            }
+            else if (IsValidFile(privatekey) == true)
+            {
+                // assume this is the image file
+                using (Bitmap bitmap = (Bitmap)Bitmap.FromFile(privatekey))
+                {
+                    IBarcodeReader reader = new BarcodeReader();
+                    var result = reader.Decode(bitmap);
+                    if (result != null)
+                    {
+                        privatekey = result.Text;
+                    }
+                }
+            }
 
-			string issuer = null;
-			string serial = null;
+            string issuer = null;
+            string serial = null;
 
-			// check for otpauth://, e.g. "otpauth://totp/dc3bf64c-2fd4-40fe-a8cf-83315945f08b@blockchain.info?secret=IHZJDKAEEC774BMUK3GX6SA"
-			match = Regex.Match(privatekey, @"otpauth://([^/]+)/([^?]+)\?(.*)", RegexOptions.IgnoreCase);
-			if (match.Success == true)
-			{
-				authtype = match.Groups[1].Value.ToLower();
-				string label = match.Groups[2].Value;
-				int p = label.IndexOf(":");
-				if (p != -1)
-				{
-					issuer = label.Substring(0, p);
-					label = label.Substring(p + 1);
-				}
+            // check for otpauth://, e.g. "otpauth://totp/dc3bf64c-2fd4-40fe-a8cf-83315945f08b@blockchain.info?secret=IHZJDKAEEC774BMUK3GX6SA"
+            match = Regex.Match(privatekey, @"otpauth://([^/]+)/([^?]+)\?(.*)", RegexOptions.IgnoreCase);
+            if (match.Success == true)
+            {
+                authtype = match.Groups[1].Value.ToLower();
+                string label = match.Groups[2].Value;
+                int p = label.IndexOf(":");
+                if (p != -1)
+                {
+                    issuer = label.Substring(0, p);
+                    label = label.Substring(p + 1);
+                }
 
-				NameValueCollection qs = WinAuthHelper.ParseQueryString(match.Groups[3].Value);
-				privatekey = qs["secret"] ?? privatekey;
-				int querydigits;
-				if (int.TryParse(qs["digits"], out querydigits) && querydigits != 0)
-				{
-					digits = querydigits;
-				}
-				if (qs["counter"] != null)
-				{
-					long.TryParse(qs["counter"], out counter);
-				}
-				issuer = qs["issuer"];
-				if (string.IsNullOrEmpty(issuer) == false)
-				{
-					label = issuer + (string.IsNullOrEmpty(label) == false ? " (" + label + ")" : string.Empty);
-				}
-				serial = qs["serial"];
+                NameValueCollection qs = WinAuthHelper.ParseQueryString(match.Groups[3].Value);
+                privatekey = qs["secret"] ?? privatekey;
+                int querydigits;
+                if (int.TryParse(qs["digits"], out querydigits) && querydigits != 0)
+                {
+                    digits = querydigits;
+                }
+                if (qs["counter"] != null)
+                {
+                    long.TryParse(qs["counter"], out counter);
+                }
+                issuer = qs["issuer"];
+                if (string.IsNullOrEmpty(issuer) == false)
+                {
+                    label = issuer + (string.IsNullOrEmpty(label) == false ? " (" + label + ")" : string.Empty);
+                }
+                serial = qs["serial"];
 
-				if (string.IsNullOrEmpty(label) == false)
-				{
-					this.Authenticator.Name = this.nameField.Text = label;
-				}
-			}
+                if (string.IsNullOrEmpty(label) == false)
+                {
+                    this.Authenticator.Name = this.nameField.Text = label;
+                }
+            }
 
-			// just get the hex chars
-			privatekey = Regex.Replace(privatekey, @"[^0-9a-z]", "", RegexOptions.IgnoreCase);
-			if (privatekey.Length == 0)
-			{
-				WinAuthForm.ErrorDialog(this.Owner, "The secret code is not valid");
-				return false;
-			}
+            // just get the hex chars
+            privatekey = Regex.Replace(privatekey, @"[^0-9a-z]", "", RegexOptions.IgnoreCase);
+            if (privatekey.Length == 0)
+            {
+                WinAuthForm.ErrorDialog(this.Owner, "The secret code is not valid");
+                return false;
+            }
 
-			try
-			{
-				Authenticator auth;
-				if (authtype == TOTP)
-				{
-					if (string.Compare(issuer, "BattleNet", true) == 0)
-					{
-						if (string.IsNullOrEmpty(serial) == true)
-						{
-							throw new ApplicationException("Battle.net Authenticator does not have a serial");
-						}
-						serial = serial.ToUpper();
-						if (Regex.IsMatch(serial, @"^[A-Z]{2}-?[\d]{4}-?[\d]{4}-?[\d]{4}$") == false)
-						{
-							throw new ApplicationException("Invalid serial for Battle.net Authenticator");
-						}
-						auth = new BattleNetAuthenticator();
-						((BattleNetAuthenticator)auth).SecretKey = Base32.getInstance().Decode(privatekey);
-						((BattleNetAuthenticator)auth).Serial = serial;
+            try
+            {
+                Authenticator auth;
+                if (authtype == TOTP)
+                {
+                    if (string.Compare(issuer, "BattleNet", true) == 0)
+                    {
+                        if (string.IsNullOrEmpty(serial) == true)
+                        {
+                            throw new ApplicationException("Battle.net Authenticator does not have a serial");
+                        }
+                        serial = serial.ToUpper();
+                        if (Regex.IsMatch(serial, @"^[A-Z]{2}-?[\d]{4}-?[\d]{4}-?[\d]{4}$") == false)
+                        {
+                            throw new ApplicationException("Invalid serial for Battle.net Authenticator");
+                        }
+                        auth = new BattleNetAuthenticator();
+                        ((BattleNetAuthenticator)auth).SecretKey = Base32.getInstance().Decode(privatekey);
+                        ((BattleNetAuthenticator)auth).Serial = serial;
 
-						issuer = string.Empty;
-					}
-					else if (issuer == "Steam")
-					{
-						auth = new SteamAuthenticator();
-						((SteamAuthenticator)auth).SecretKey = Base32.getInstance().Decode(privatekey);
-						((SteamAuthenticator)auth).Serial = string.Empty;
-						((SteamAuthenticator)auth).DeviceId = string.Empty;
-						//((SteamAuthenticator)auth).RevocationCode = string.Empty;
-						((SteamAuthenticator)auth).SteamData = string.Empty;
+                        issuer = string.Empty;
+                    }
+                    else if (issuer == "Steam")
+                    {
+                        auth = new SteamAuthenticator();
+                        ((SteamAuthenticator)auth).SecretKey = Base32.getInstance().Decode(privatekey);
+                        ((SteamAuthenticator)auth).Serial = string.Empty;
+                        ((SteamAuthenticator)auth).DeviceId = string.Empty;
+                        //((SteamAuthenticator)auth).RevocationCode = string.Empty;
+                        ((SteamAuthenticator)auth).SteamData = string.Empty;
 
-						this.Authenticator.Skin = null;
+                        this.Authenticator.Skin = null;
 
-						issuer = string.Empty;
-					}
-					else
-					{
-						auth = new GoogleAuthenticator();
-						((GoogleAuthenticator)auth).Enroll(privatekey);
-					}
-					timer.Enabled = true;
-					codeProgress.Visible = true;
-					timeBasedRadio.Checked = true;
-				}
-				else if (authtype == HOTP)
-				{
-					auth = new HOTPAuthenticator();
-					if (counterField.Text.Trim().Length != 0)
-					{
-						long.TryParse(counterField.Text.Trim(), out counter);
-					}
-					((HOTPAuthenticator)auth).Enroll(privatekey, counter); // start with the next code
-					timer.Enabled = false;
-					codeProgress.Visible = false;
-					counterBasedRadio.Checked = true;
-				}
-				else
-				{
-					WinAuthForm.ErrorDialog(this.Owner, "Only TOTP or HOTP authenticators are supported");
-					return false;
-				}
+                        issuer = string.Empty;
+                    }
+                    else
+                    {
+                        auth = new GoogleAuthenticator();
+                        ((GoogleAuthenticator)auth).Enroll(privatekey);
+                    }
+                    timer.Enabled = true;
+                    codeProgress.Visible = true;
+                    timeBasedRadio.Checked = true;
+                }
+                else if (authtype == HOTP)
+                {
+                    auth = new HOTPAuthenticator();
+                    if (counterField.Text.Trim().Length != 0)
+                    {
+                        long.TryParse(counterField.Text.Trim(), out counter);
+                    }
+                    ((HOTPAuthenticator)auth).Enroll(privatekey, counter); // start with the next code
+                    timer.Enabled = false;
+                    codeProgress.Visible = false;
+                    counterBasedRadio.Checked = true;
+                }
+                else
+                {
+                    WinAuthForm.ErrorDialog(this.Owner, "Only TOTP or HOTP authenticators are supported");
+                    return false;
+                }
 
-				auth.CodeDigits = digits;
-				this.Authenticator.AuthenticatorData = auth;
+                auth.CodeDigits = digits;
+                this.Authenticator.AuthenticatorData = auth;
 
-				if (digits > 5)
-				{
-					codeField.SpaceOut = digits / 2;
-				}
-				else
-				{
-					codeField.SpaceOut = 0;
-				}
+                if (digits > 5)
+                {
+                    codeField.SpaceOut = digits / 2;
+                }
+                else
+                {
+                    codeField.SpaceOut = 0;
+                }
 
-				//string key = Base32.getInstance().Encode(this.Authenticator.AuthenticatorData.SecretKey);
-				this.codeField.Text = auth.CurrentCode;
+                //string key = Base32.getInstance().Encode(this.Authenticator.AuthenticatorData.SecretKey);
+                this.codeField.Text = auth.CurrentCode;
 
-				if (!(auth is HOTPAuthenticator) && auth.ServerTimeDiff == 0L && SyncErrorWarned == false)
-				{
-					SyncErrorWarned = true;
-					MessageBox.Show(this, string.Format(strings.AuthenticatorSyncError, "Google"), WinAuthMain.APPLICATION_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-				}
-			}
-			catch (Exception irre)
-			{
-				WinAuthForm.ErrorDialog(this.Owner, "Unable to create the authenticator. The secret code is probably invalid.", irre);
-				return false;
-			}
+                if (!(auth is HOTPAuthenticator) && auth.ServerTimeDiff == 0L && SyncErrorWarned == false)
+                {
+                    SyncErrorWarned = true;
+                    MessageBox.Show(this, string.Format(strings.AuthenticatorSyncError, "Google"), WinAuthMain.APPLICATION_TITLE, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+            catch (Exception irre)
+            {
+                WinAuthForm.ErrorDialog(this.Owner, "Unable to create the authenticator. The secret code is probably invalid.", irre);
+                return false;
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-#endregion
+        #endregion
 
 
-	}
+    }
 }

--- a/WinAuth/AddAuthenticator.designer.cs
+++ b/WinAuth/AddAuthenticator.designer.cs
@@ -39,17 +39,19 @@ namespace WinAuth
             this.verifyButton = new MetroFramework.Controls.MetroButton();
             this.codeProgress = new System.Windows.Forms.ProgressBar();
             this.codeField = new WinAuth.SecretTextBox();
-            this.step4Label = new MetroFramework.Controls.MetroLabel();
+            this.step5Label = new MetroFramework.Controls.MetroLabel();
             this.timer = new System.Windows.Forms.Timer(this.components);
-            this.step3Label = new MetroFramework.Controls.MetroLabel();
+            this.step4TimerLabel = new MetroFramework.Controls.MetroLabel();
             this.timeBasedRadio = new MetroFramework.Controls.MetroRadioButton();
             this.counterBasedRadio = new MetroFramework.Controls.MetroRadioButton();
             this.timeBasedPanel = new System.Windows.Forms.Panel();
             this.counterBasedPanel = new System.Windows.Forms.Panel();
             this.verifyCounterButton = new MetroFramework.Controls.MetroButton();
             this.counterField = new MetroFramework.Controls.MetroTextBox();
-            this.step3CounterLabel = new MetroFramework.Controls.MetroLabel();
+            this.step4CounterLabel = new MetroFramework.Controls.MetroLabel();
             this.secretCodeButton = new MetroFramework.Controls.MetroButton();
+            this.step3Label = new MetroFramework.Controls.MetroLabel();
+            this.cmbHMACType = new System.Windows.Forms.ComboBox();
             this.timeBasedPanel.SuspendLayout();
             this.counterBasedPanel.SuspendLayout();
             this.SuspendLayout();
@@ -70,18 +72,18 @@ namespace WinAuth
             //
             // step1Label
             //
-            this.step1Label.Location = new System.Drawing.Point(25, 120);
+            this.step1Label.Location = new System.Drawing.Point(28, 120);
             this.step1Label.Name = "step1Label";
             this.step1Label.Size = new System.Drawing.Size(425, 48);
             this.step1Label.TabIndex = 1;
-            this.step1Label.Text = "1. Enter the Secret Code for your authenticator. Spaces don\'t matter. If you have a Q" +
-    "R code, you can paste the URL of the image instead.\r\n";
+            this.step1Label.Text = "1. Enter the Secret Code for your authenticator. Spaces don\'t matter. If you have" +
+    " a QR code, you can paste the URL of the image instead.\r\n";
             //
             // okButton
             //
             this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(292, 470);
+            this.okButton.Location = new System.Drawing.Point(292, 557);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 6;
@@ -93,7 +95,7 @@ namespace WinAuth
             //
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(373, 470);
+            this.cancelButton.Location = new System.Drawing.Point(373, 557);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 7;
@@ -104,7 +106,7 @@ namespace WinAuth
             // nameLabel
             //
             this.nameLabel.AutoSize = true;
-            this.nameLabel.Location = new System.Drawing.Point(23, 70);
+            this.nameLabel.Location = new System.Drawing.Point(28, 70);
             this.nameLabel.Name = "nameLabel";
             this.nameLabel.Size = new System.Drawing.Size(48, 19);
             this.nameLabel.TabIndex = 3;
@@ -112,19 +114,19 @@ namespace WinAuth
             //
             // nameField
             //
-            this.nameField.Location = new System.Drawing.Point(77, 67);
+            this.nameField.Location = new System.Drawing.Point(82, 67);
             this.nameField.MaxLength = 32767;
             this.nameField.Name = "nameField";
             this.nameField.PasswordChar = '\0';
             this.nameField.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.nameField.SelectedText = "";
-            this.nameField.Size = new System.Drawing.Size(371, 22);
+            this.nameField.Size = new System.Drawing.Size(366, 22);
             this.nameField.TabIndex = 0;
             this.nameField.UseSelectable = true;
             //
             // step2Label
             //
-            this.step2Label.Location = new System.Drawing.Point(25, 213);
+            this.step2Label.Location = new System.Drawing.Point(28, 213);
             this.step2Label.Name = "step2Label";
             this.step2Label.Size = new System.Drawing.Size(423, 49);
             this.step2Label.TabIndex = 10;
@@ -143,7 +145,7 @@ namespace WinAuth
             //
             // codeProgress
             //
-            this.codeProgress.Location = new System.Drawing.Point(124, 433);
+            this.codeProgress.Location = new System.Drawing.Point(124, 524);
             this.codeProgress.Maximum = 30;
             this.codeProgress.Minimum = 1;
             this.codeProgress.Name = "codeProgress";
@@ -156,7 +158,7 @@ namespace WinAuth
             // codeField
             //
             this.codeField.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
-            this.codeField.Location = new System.Drawing.Point(124, 405);
+            this.codeField.Location = new System.Drawing.Point(124, 492);
             this.codeField.Multiline = true;
             this.codeField.Name = "codeField";
             this.codeField.SecretMode = false;
@@ -164,14 +166,14 @@ namespace WinAuth
             this.codeField.SpaceOut = 3;
             this.codeField.TabIndex = 5;
             //
-            // step4Label
+            // step5Label
             //
-            this.step4Label.AutoSize = true;
-            this.step4Label.Location = new System.Drawing.Point(25, 373);
-            this.step4Label.Name = "step4Label";
-            this.step4Label.Size = new System.Drawing.Size(293, 19);
-            this.step4Label.TabIndex = 11;
-            this.step4Label.Text = "4. Verify the following code matches your service.";
+            this.step5Label.AutoSize = true;
+            this.step5Label.Location = new System.Drawing.Point(28, 465);
+            this.step5Label.Name = "step5Label";
+            this.step5Label.Size = new System.Drawing.Size(296, 19);
+            this.step5Label.TabIndex = 11;
+            this.step5Label.Text = "5. Verify the following code matches your service.";
             //
             // timer
             //
@@ -179,19 +181,19 @@ namespace WinAuth
             this.timer.Interval = 500;
             this.timer.Tick += new System.EventHandler(this.timer_Tick);
             //
-            // step3Label
+            // step4TimerLabel
             //
-            this.step3Label.Location = new System.Drawing.Point(23, 12);
-            this.step3Label.Name = "step3Label";
-            this.step3Label.Size = new System.Drawing.Size(423, 28);
-            this.step3Label.TabIndex = 10;
-            this.step3Label.Text = "3. Click the Verify button to check the first code.";
+            this.step4TimerLabel.Location = new System.Drawing.Point(23, 12);
+            this.step4TimerLabel.Name = "step4TimerLabel";
+            this.step4TimerLabel.Size = new System.Drawing.Size(423, 28);
+            this.step4TimerLabel.TabIndex = 10;
+            this.step4TimerLabel.Text = "4. Click the Verify button to check the first code.";
             //
             // timeBasedRadio
             //
             this.timeBasedRadio.AutoSize = true;
             this.timeBasedRadio.Checked = true;
-            this.timeBasedRadio.Location = new System.Drawing.Point(43, 265);
+            this.timeBasedRadio.Location = new System.Drawing.Point(82, 265);
             this.timeBasedRadio.Name = "timeBasedRadio";
             this.timeBasedRadio.Size = new System.Drawing.Size(86, 15);
             this.timeBasedRadio.TabIndex = 3;
@@ -203,7 +205,7 @@ namespace WinAuth
             // counterBasedRadio
             //
             this.counterBasedRadio.AutoSize = true;
-            this.counterBasedRadio.Location = new System.Drawing.Point(146, 265);
+            this.counterBasedRadio.Location = new System.Drawing.Point(252, 265);
             this.counterBasedRadio.Name = "counterBasedRadio";
             this.counterBasedRadio.Size = new System.Drawing.Size(102, 15);
             this.counterBasedRadio.TabIndex = 4;
@@ -215,9 +217,9 @@ namespace WinAuth
             //
             this.timeBasedPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.timeBasedPanel.Controls.Add(this.step3Label);
+            this.timeBasedPanel.Controls.Add(this.step4TimerLabel);
             this.timeBasedPanel.Controls.Add(this.verifyButton);
-            this.timeBasedPanel.Location = new System.Drawing.Point(2, 286);
+            this.timeBasedPanel.Location = new System.Drawing.Point(5, 367);
             this.timeBasedPanel.Name = "timeBasedPanel";
             this.timeBasedPanel.Size = new System.Drawing.Size(464, 84);
             this.timeBasedPanel.TabIndex = 15;
@@ -228,8 +230,8 @@ namespace WinAuth
             | System.Windows.Forms.AnchorStyles.Right)));
             this.counterBasedPanel.Controls.Add(this.verifyCounterButton);
             this.counterBasedPanel.Controls.Add(this.counterField);
-            this.counterBasedPanel.Controls.Add(this.step3CounterLabel);
-            this.counterBasedPanel.Location = new System.Drawing.Point(2, 286);
+            this.counterBasedPanel.Controls.Add(this.step4CounterLabel);
+            this.counterBasedPanel.Location = new System.Drawing.Point(5, 367);
             this.counterBasedPanel.Name = "counterBasedPanel";
             this.counterBasedPanel.Size = new System.Drawing.Size(464, 84);
             this.counterBasedPanel.TabIndex = 16;
@@ -237,7 +239,7 @@ namespace WinAuth
             //
             // verifyCounterButton
             //
-            this.verifyCounterButton.Location = new System.Drawing.Point(207, 58);
+            this.verifyCounterButton.Location = new System.Drawing.Point(204, 56);
             this.verifyCounterButton.Name = "verifyCounterButton";
             this.verifyCounterButton.Size = new System.Drawing.Size(158, 23);
             this.verifyCounterButton.TabIndex = 1;
@@ -249,23 +251,23 @@ namespace WinAuth
             //
             this.counterField.AllowDrop = true;
             this.counterField.CausesValidation = false;
-            this.counterField.Location = new System.Drawing.Point(122, 58);
+            this.counterField.Location = new System.Drawing.Point(119, 58);
             this.counterField.MaxLength = 32767;
             this.counterField.Name = "counterField";
             this.counterField.PasswordChar = '\0';
             this.counterField.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.counterField.SelectedText = "";
-            this.counterField.Size = new System.Drawing.Size(74, 20);
+            this.counterField.Size = new System.Drawing.Size(79, 20);
             this.counterField.TabIndex = 0;
             this.counterField.UseSelectable = true;
             //
-            // step3CounterLabel
+            // step4CounterLabel
             //
-            this.step3CounterLabel.Location = new System.Drawing.Point(23, 12);
-            this.step3CounterLabel.Name = "step3CounterLabel";
-            this.step3CounterLabel.Size = new System.Drawing.Size(423, 43);
-            this.step3CounterLabel.TabIndex = 10;
-            this.step3CounterLabel.Text = "3. Enter the initial counter value if known. Click the Verify button that will sh" +
+            this.step4CounterLabel.Location = new System.Drawing.Point(23, 12);
+            this.step4CounterLabel.Name = "step4CounterLabel";
+            this.step4CounterLabel.Size = new System.Drawing.Size(423, 43);
+            this.step4CounterLabel.TabIndex = 10;
+            this.step4CounterLabel.Text = "4. Enter the initial counter value if known. Click the Verify button that will sh" +
     "ow the last code that was used.";
             //
             // secretCodeButton
@@ -278,6 +280,28 @@ namespace WinAuth
             this.secretCodeButton.UseSelectable = true;
             this.secretCodeButton.Click += new System.EventHandler(this.secretCodeButton_Click);
             //
+            // step3Label
+            //
+            this.step3Label.Location = new System.Drawing.Point(28, 294);
+            this.step3Label.Name = "step3Label";
+            this.step3Label.Size = new System.Drawing.Size(423, 43);
+            this.step3Label.TabIndex = 17;
+            this.step3Label.Text = "3. Select the HMAC algorithm type used by this authenticator (most authenticator " +
+    "tokens use HMAC-SHA1).";
+            //
+            // cmbHMACType
+            //
+            this.cmbHMACType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbHMACType.FormattingEnabled = true;
+            this.cmbHMACType.Items.AddRange(new object[] {
+            "HMAC-SHA1",
+            "HMAC-SHA256",
+            "HMAC-SHA512"});
+            this.cmbHMACType.Location = new System.Drawing.Point(124, 340);
+            this.cmbHMACType.Name = "cmbHMACType";
+            this.cmbHMACType.Size = new System.Drawing.Size(243, 21);
+            this.cmbHMACType.TabIndex = 18;
+            //
             // AddAuthenticator
             //
             this.AcceptButton = this.okButton;
@@ -285,15 +309,17 @@ namespace WinAuth
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BorderStyle = MetroFramework.Forms.MetroFormBorderStyle.FixedSingle;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(471, 516);
-            this.Controls.Add(this.secretCodeButton);
+            this.ClientSize = new System.Drawing.Size(471, 603);
+            this.Controls.Add(this.cmbHMACType);
+            this.Controls.Add(this.step3Label);
             this.Controls.Add(this.counterBasedPanel);
+            this.Controls.Add(this.secretCodeButton);
             this.Controls.Add(this.timeBasedPanel);
             this.Controls.Add(this.counterBasedRadio);
             this.Controls.Add(this.timeBasedRadio);
             this.Controls.Add(this.codeProgress);
             this.Controls.Add(this.codeField);
-            this.Controls.Add(this.step4Label);
+            this.Controls.Add(this.step5Label);
             this.Controls.Add(this.step2Label);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
@@ -326,16 +352,18 @@ namespace WinAuth
         private MetroFramework.Controls.MetroButton verifyButton;
         private System.Windows.Forms.ProgressBar codeProgress;
         private SecretTextBox codeField;
-        private MetroFramework.Controls.MetroLabel step4Label;
+        private MetroFramework.Controls.MetroLabel step5Label;
         private System.Windows.Forms.Timer timer;
-        private MetroFramework.Controls.MetroLabel step3Label;
+        private MetroFramework.Controls.MetroLabel step4TimerLabel;
         private MetroFramework.Controls.MetroRadioButton timeBasedRadio;
         private MetroFramework.Controls.MetroRadioButton counterBasedRadio;
         private System.Windows.Forms.Panel timeBasedPanel;
         private System.Windows.Forms.Panel counterBasedPanel;
-        private MetroFramework.Controls.MetroLabel step3CounterLabel;
+        private MetroFramework.Controls.MetroLabel step4CounterLabel;
         private MetroFramework.Controls.MetroTextBox counterField;
         private MetroFramework.Controls.MetroButton verifyCounterButton;
         private MetroFramework.Controls.MetroButton secretCodeButton;
+        private MetroFramework.Controls.MetroLabel step3Label;
+        private System.Windows.Forms.ComboBox cmbHMACType;
     }
 }

--- a/WinAuth/AddAuthenticator.designer.cs
+++ b/WinAuth/AddAuthenticator.designer.cs
@@ -1,341 +1,341 @@
 namespace WinAuth
 {
-	partial class AddAuthenticator
-	{
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
-		private System.ComponentModel.IContainer components = null;
+    partial class AddAuthenticator
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
 
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && (components != null))
-			{
-				components.Dispose();
-			}
-			base.Dispose(disposing);
-		}
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
-		#region Windows Form Designer generated code
+        #region Windows Form Designer generated code
 
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
-			this.components = new System.ComponentModel.Container();
-			this.secretCodeField = new MetroFramework.Controls.MetroTextBox();
-			this.step1Label = new MetroFramework.Controls.MetroLabel();
-			this.okButton = new MetroFramework.Controls.MetroButton();
-			this.cancelButton = new MetroFramework.Controls.MetroButton();
-			this.nameLabel = new MetroFramework.Controls.MetroLabel();
-			this.nameField = new MetroFramework.Controls.MetroTextBox();
-			this.step2Label = new MetroFramework.Controls.MetroLabel();
-			this.verifyButton = new MetroFramework.Controls.MetroButton();
-			this.codeProgress = new System.Windows.Forms.ProgressBar();
-			this.codeField = new WinAuth.SecretTextBox();
-			this.step4Label = new MetroFramework.Controls.MetroLabel();
-			this.timer = new System.Windows.Forms.Timer(this.components);
-			this.step3Label = new MetroFramework.Controls.MetroLabel();
-			this.timeBasedRadio = new MetroFramework.Controls.MetroRadioButton();
-			this.counterBasedRadio = new MetroFramework.Controls.MetroRadioButton();
-			this.timeBasedPanel = new System.Windows.Forms.Panel();
-			this.counterBasedPanel = new System.Windows.Forms.Panel();
-			this.verifyCounterButton = new MetroFramework.Controls.MetroButton();
-			this.counterField = new MetroFramework.Controls.MetroTextBox();
-			this.step3CounterLabel = new MetroFramework.Controls.MetroLabel();
-			this.secretCodeButton = new MetroFramework.Controls.MetroButton();
-			this.timeBasedPanel.SuspendLayout();
-			this.counterBasedPanel.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// secretCodeField
-			// 
-			this.secretCodeField.AllowDrop = true;
-			this.secretCodeField.CausesValidation = false;
-			this.secretCodeField.Location = new System.Drawing.Point(43, 171);
-			this.secretCodeField.MaxLength = 32767;
-			this.secretCodeField.Name = "secretCodeField";
-			this.secretCodeField.PasswordChar = '\0';
-			this.secretCodeField.ScrollBars = System.Windows.Forms.ScrollBars.None;
-			this.secretCodeField.SelectedText = "";
-			this.secretCodeField.Size = new System.Drawing.Size(311, 22);
-			this.secretCodeField.TabIndex = 1;
-			this.secretCodeField.UseSelectable = true;
-			// 
-			// step1Label
-			// 
-			this.step1Label.Location = new System.Drawing.Point(25, 120);
-			this.step1Label.Name = "step1Label";
-			this.step1Label.Size = new System.Drawing.Size(425, 48);
-			this.step1Label.TabIndex = 1;
-			this.step1Label.Text = "1. Enter the Secret Code for your authenticator. Spaces don\'t matter. If you have a Q" +
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.secretCodeField = new MetroFramework.Controls.MetroTextBox();
+            this.step1Label = new MetroFramework.Controls.MetroLabel();
+            this.okButton = new MetroFramework.Controls.MetroButton();
+            this.cancelButton = new MetroFramework.Controls.MetroButton();
+            this.nameLabel = new MetroFramework.Controls.MetroLabel();
+            this.nameField = new MetroFramework.Controls.MetroTextBox();
+            this.step2Label = new MetroFramework.Controls.MetroLabel();
+            this.verifyButton = new MetroFramework.Controls.MetroButton();
+            this.codeProgress = new System.Windows.Forms.ProgressBar();
+            this.codeField = new WinAuth.SecretTextBox();
+            this.step4Label = new MetroFramework.Controls.MetroLabel();
+            this.timer = new System.Windows.Forms.Timer(this.components);
+            this.step3Label = new MetroFramework.Controls.MetroLabel();
+            this.timeBasedRadio = new MetroFramework.Controls.MetroRadioButton();
+            this.counterBasedRadio = new MetroFramework.Controls.MetroRadioButton();
+            this.timeBasedPanel = new System.Windows.Forms.Panel();
+            this.counterBasedPanel = new System.Windows.Forms.Panel();
+            this.verifyCounterButton = new MetroFramework.Controls.MetroButton();
+            this.counterField = new MetroFramework.Controls.MetroTextBox();
+            this.step3CounterLabel = new MetroFramework.Controls.MetroLabel();
+            this.secretCodeButton = new MetroFramework.Controls.MetroButton();
+            this.timeBasedPanel.SuspendLayout();
+            this.counterBasedPanel.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // secretCodeField
+            //
+            this.secretCodeField.AllowDrop = true;
+            this.secretCodeField.CausesValidation = false;
+            this.secretCodeField.Location = new System.Drawing.Point(43, 171);
+            this.secretCodeField.MaxLength = 32767;
+            this.secretCodeField.Name = "secretCodeField";
+            this.secretCodeField.PasswordChar = '\0';
+            this.secretCodeField.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.secretCodeField.SelectedText = "";
+            this.secretCodeField.Size = new System.Drawing.Size(311, 22);
+            this.secretCodeField.TabIndex = 1;
+            this.secretCodeField.UseSelectable = true;
+            //
+            // step1Label
+            //
+            this.step1Label.Location = new System.Drawing.Point(25, 120);
+            this.step1Label.Name = "step1Label";
+            this.step1Label.Size = new System.Drawing.Size(425, 48);
+            this.step1Label.TabIndex = 1;
+            this.step1Label.Text = "1. Enter the Secret Code for your authenticator. Spaces don\'t matter. If you have a Q" +
     "R code, you can paste the URL of the image instead.\r\n";
-			// 
-			// okButton
-			// 
-			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.okButton.Location = new System.Drawing.Point(292, 470);
-			this.okButton.Name = "okButton";
-			this.okButton.Size = new System.Drawing.Size(75, 23);
-			this.okButton.TabIndex = 6;
-			this.okButton.Text = "OK";
-			this.okButton.UseSelectable = true;
-			this.okButton.Click += new System.EventHandler(this.okButton_Click);
-			// 
-			// cancelButton
-			// 
-			this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancelButton.Location = new System.Drawing.Point(373, 470);
-			this.cancelButton.Name = "cancelButton";
-			this.cancelButton.Size = new System.Drawing.Size(75, 23);
-			this.cancelButton.TabIndex = 7;
-			this.cancelButton.Text = "Cancel";
-			this.cancelButton.UseSelectable = true;
-			this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
-			// 
-			// nameLabel
-			// 
-			this.nameLabel.AutoSize = true;
-			this.nameLabel.Location = new System.Drawing.Point(23, 70);
-			this.nameLabel.Name = "nameLabel";
-			this.nameLabel.Size = new System.Drawing.Size(48, 19);
-			this.nameLabel.TabIndex = 3;
-			this.nameLabel.Text = "Name:";
-			// 
-			// nameField
-			// 
-			this.nameField.Location = new System.Drawing.Point(77, 67);
-			this.nameField.MaxLength = 32767;
-			this.nameField.Name = "nameField";
-			this.nameField.PasswordChar = '\0';
-			this.nameField.ScrollBars = System.Windows.Forms.ScrollBars.None;
-			this.nameField.SelectedText = "";
-			this.nameField.Size = new System.Drawing.Size(371, 22);
-			this.nameField.TabIndex = 0;
-			this.nameField.UseSelectable = true;
-			// 
-			// step2Label
-			// 
-			this.step2Label.Location = new System.Drawing.Point(25, 213);
-			this.step2Label.Name = "step2Label";
-			this.step2Label.Size = new System.Drawing.Size(423, 49);
-			this.step2Label.TabIndex = 10;
-			this.step2Label.Text = "2. Choose if this is a time-based or a counter-based authenticator. If you don\'t " +
+            //
+            // okButton
+            //
+            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.okButton.Location = new System.Drawing.Point(292, 470);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 6;
+            this.okButton.Text = "OK";
+            this.okButton.UseSelectable = true;
+            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            //
+            // cancelButton
+            //
+            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(373, 470);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 7;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseSelectable = true;
+            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            //
+            // nameLabel
+            //
+            this.nameLabel.AutoSize = true;
+            this.nameLabel.Location = new System.Drawing.Point(23, 70);
+            this.nameLabel.Name = "nameLabel";
+            this.nameLabel.Size = new System.Drawing.Size(48, 19);
+            this.nameLabel.TabIndex = 3;
+            this.nameLabel.Text = "Name:";
+            //
+            // nameField
+            //
+            this.nameField.Location = new System.Drawing.Point(77, 67);
+            this.nameField.MaxLength = 32767;
+            this.nameField.Name = "nameField";
+            this.nameField.PasswordChar = '\0';
+            this.nameField.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.nameField.SelectedText = "";
+            this.nameField.Size = new System.Drawing.Size(371, 22);
+            this.nameField.TabIndex = 0;
+            this.nameField.UseSelectable = true;
+            //
+            // step2Label
+            //
+            this.step2Label.Location = new System.Drawing.Point(25, 213);
+            this.step2Label.Name = "step2Label";
+            this.step2Label.Size = new System.Drawing.Size(423, 49);
+            this.step2Label.TabIndex = 10;
+            this.step2Label.Text = "2. Choose if this is a time-based or a counter-based authenticator. If you don\'t " +
     "know, it\'s likely time-based, so just leave the default choice.";
-			// 
-			// verifyButton
-			// 
-			this.verifyButton.Location = new System.Drawing.Point(122, 43);
-			this.verifyButton.Name = "verifyButton";
-			this.verifyButton.Size = new System.Drawing.Size(158, 23);
-			this.verifyButton.TabIndex = 0;
-			this.verifyButton.Text = "Verify Authenticator";
-			this.verifyButton.UseSelectable = true;
-			this.verifyButton.Click += new System.EventHandler(this.verifyButton_Click);
-			// 
-			// codeProgress
-			// 
-			this.codeProgress.Location = new System.Drawing.Point(124, 433);
-			this.codeProgress.Maximum = 30;
-			this.codeProgress.Minimum = 1;
-			this.codeProgress.Name = "codeProgress";
-			this.codeProgress.Size = new System.Drawing.Size(158, 8);
-			this.codeProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-			this.codeProgress.TabIndex = 13;
-			this.codeProgress.Value = 1;
-			this.codeProgress.Visible = false;
-			// 
-			// codeField
-			// 
-			this.codeField.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
-			this.codeField.Location = new System.Drawing.Point(124, 405);
-			this.codeField.Multiline = true;
-			this.codeField.Name = "codeField";
-			this.codeField.SecretMode = false;
-			this.codeField.Size = new System.Drawing.Size(158, 26);
-			this.codeField.SpaceOut = 3;
-			this.codeField.TabIndex = 5;
-			// 
-			// step4Label
-			// 
-			this.step4Label.AutoSize = true;
-			this.step4Label.Location = new System.Drawing.Point(25, 373);
-			this.step4Label.Name = "step4Label";
-			this.step4Label.Size = new System.Drawing.Size(293, 19);
-			this.step4Label.TabIndex = 11;
-			this.step4Label.Text = "4. Verify the following code matches your service.";
-			// 
-			// timer
-			// 
-			this.timer.Enabled = true;
-			this.timer.Interval = 500;
-			this.timer.Tick += new System.EventHandler(this.timer_Tick);
-			// 
-			// step3Label
-			// 
-			this.step3Label.Location = new System.Drawing.Point(23, 12);
-			this.step3Label.Name = "step3Label";
-			this.step3Label.Size = new System.Drawing.Size(423, 28);
-			this.step3Label.TabIndex = 10;
-			this.step3Label.Text = "3. Click the Verify button to check the first code.";
-			// 
-			// timeBasedRadio
-			// 
-			this.timeBasedRadio.AutoSize = true;
-			this.timeBasedRadio.Checked = true;
-			this.timeBasedRadio.Location = new System.Drawing.Point(43, 265);
-			this.timeBasedRadio.Name = "timeBasedRadio";
-			this.timeBasedRadio.Size = new System.Drawing.Size(86, 15);
-			this.timeBasedRadio.TabIndex = 3;
-			this.timeBasedRadio.TabStop = true;
-			this.timeBasedRadio.Text = "Time-based";
-			this.timeBasedRadio.UseSelectable = true;
-			this.timeBasedRadio.CheckedChanged += new System.EventHandler(this.timeBasedRadio_CheckedChanged);
-			// 
-			// counterBasedRadio
-			// 
-			this.counterBasedRadio.AutoSize = true;
-			this.counterBasedRadio.Location = new System.Drawing.Point(146, 265);
-			this.counterBasedRadio.Name = "counterBasedRadio";
-			this.counterBasedRadio.Size = new System.Drawing.Size(102, 15);
-			this.counterBasedRadio.TabIndex = 4;
-			this.counterBasedRadio.Text = "Counter-based";
-			this.counterBasedRadio.UseSelectable = true;
-			this.counterBasedRadio.CheckedChanged += new System.EventHandler(this.counterBasedRadio_CheckedChanged);
-			// 
-			// timeBasedPanel
-			// 
-			this.timeBasedPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            // verifyButton
+            //
+            this.verifyButton.Location = new System.Drawing.Point(122, 43);
+            this.verifyButton.Name = "verifyButton";
+            this.verifyButton.Size = new System.Drawing.Size(158, 23);
+            this.verifyButton.TabIndex = 0;
+            this.verifyButton.Text = "Verify Authenticator";
+            this.verifyButton.UseSelectable = true;
+            this.verifyButton.Click += new System.EventHandler(this.verifyButton_Click);
+            //
+            // codeProgress
+            //
+            this.codeProgress.Location = new System.Drawing.Point(124, 433);
+            this.codeProgress.Maximum = 30;
+            this.codeProgress.Minimum = 1;
+            this.codeProgress.Name = "codeProgress";
+            this.codeProgress.Size = new System.Drawing.Size(158, 8);
+            this.codeProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            this.codeProgress.TabIndex = 13;
+            this.codeProgress.Value = 1;
+            this.codeProgress.Visible = false;
+            //
+            // codeField
+            //
+            this.codeField.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F);
+            this.codeField.Location = new System.Drawing.Point(124, 405);
+            this.codeField.Multiline = true;
+            this.codeField.Name = "codeField";
+            this.codeField.SecretMode = false;
+            this.codeField.Size = new System.Drawing.Size(158, 26);
+            this.codeField.SpaceOut = 3;
+            this.codeField.TabIndex = 5;
+            //
+            // step4Label
+            //
+            this.step4Label.AutoSize = true;
+            this.step4Label.Location = new System.Drawing.Point(25, 373);
+            this.step4Label.Name = "step4Label";
+            this.step4Label.Size = new System.Drawing.Size(293, 19);
+            this.step4Label.TabIndex = 11;
+            this.step4Label.Text = "4. Verify the following code matches your service.";
+            //
+            // timer
+            //
+            this.timer.Enabled = true;
+            this.timer.Interval = 500;
+            this.timer.Tick += new System.EventHandler(this.timer_Tick);
+            //
+            // step3Label
+            //
+            this.step3Label.Location = new System.Drawing.Point(23, 12);
+            this.step3Label.Name = "step3Label";
+            this.step3Label.Size = new System.Drawing.Size(423, 28);
+            this.step3Label.TabIndex = 10;
+            this.step3Label.Text = "3. Click the Verify button to check the first code.";
+            //
+            // timeBasedRadio
+            //
+            this.timeBasedRadio.AutoSize = true;
+            this.timeBasedRadio.Checked = true;
+            this.timeBasedRadio.Location = new System.Drawing.Point(43, 265);
+            this.timeBasedRadio.Name = "timeBasedRadio";
+            this.timeBasedRadio.Size = new System.Drawing.Size(86, 15);
+            this.timeBasedRadio.TabIndex = 3;
+            this.timeBasedRadio.TabStop = true;
+            this.timeBasedRadio.Text = "Time-based";
+            this.timeBasedRadio.UseSelectable = true;
+            this.timeBasedRadio.CheckedChanged += new System.EventHandler(this.timeBasedRadio_CheckedChanged);
+            //
+            // counterBasedRadio
+            //
+            this.counterBasedRadio.AutoSize = true;
+            this.counterBasedRadio.Location = new System.Drawing.Point(146, 265);
+            this.counterBasedRadio.Name = "counterBasedRadio";
+            this.counterBasedRadio.Size = new System.Drawing.Size(102, 15);
+            this.counterBasedRadio.TabIndex = 4;
+            this.counterBasedRadio.Text = "Counter-based";
+            this.counterBasedRadio.UseSelectable = true;
+            this.counterBasedRadio.CheckedChanged += new System.EventHandler(this.counterBasedRadio_CheckedChanged);
+            //
+            // timeBasedPanel
+            //
+            this.timeBasedPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.timeBasedPanel.Controls.Add(this.step3Label);
-			this.timeBasedPanel.Controls.Add(this.verifyButton);
-			this.timeBasedPanel.Location = new System.Drawing.Point(2, 286);
-			this.timeBasedPanel.Name = "timeBasedPanel";
-			this.timeBasedPanel.Size = new System.Drawing.Size(464, 84);
-			this.timeBasedPanel.TabIndex = 15;
-			// 
-			// counterBasedPanel
-			// 
-			this.counterBasedPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.timeBasedPanel.Controls.Add(this.step3Label);
+            this.timeBasedPanel.Controls.Add(this.verifyButton);
+            this.timeBasedPanel.Location = new System.Drawing.Point(2, 286);
+            this.timeBasedPanel.Name = "timeBasedPanel";
+            this.timeBasedPanel.Size = new System.Drawing.Size(464, 84);
+            this.timeBasedPanel.TabIndex = 15;
+            //
+            // counterBasedPanel
+            //
+            this.counterBasedPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.counterBasedPanel.Controls.Add(this.verifyCounterButton);
-			this.counterBasedPanel.Controls.Add(this.counterField);
-			this.counterBasedPanel.Controls.Add(this.step3CounterLabel);
-			this.counterBasedPanel.Location = new System.Drawing.Point(2, 286);
-			this.counterBasedPanel.Name = "counterBasedPanel";
-			this.counterBasedPanel.Size = new System.Drawing.Size(464, 84);
-			this.counterBasedPanel.TabIndex = 16;
-			this.counterBasedPanel.Visible = false;
-			// 
-			// verifyCounterButton
-			// 
-			this.verifyCounterButton.Location = new System.Drawing.Point(207, 58);
-			this.verifyCounterButton.Name = "verifyCounterButton";
-			this.verifyCounterButton.Size = new System.Drawing.Size(158, 23);
-			this.verifyCounterButton.TabIndex = 1;
-			this.verifyCounterButton.Text = "Verify Authenticator";
-			this.verifyCounterButton.UseSelectable = true;
-			this.verifyCounterButton.Click += new System.EventHandler(this.verifyButton_Click);
-			// 
-			// counterField
-			// 
-			this.counterField.AllowDrop = true;
-			this.counterField.CausesValidation = false;
-			this.counterField.Location = new System.Drawing.Point(122, 58);
-			this.counterField.MaxLength = 32767;
-			this.counterField.Name = "counterField";
-			this.counterField.PasswordChar = '\0';
-			this.counterField.ScrollBars = System.Windows.Forms.ScrollBars.None;
-			this.counterField.SelectedText = "";
-			this.counterField.Size = new System.Drawing.Size(74, 20);
-			this.counterField.TabIndex = 0;
-			this.counterField.UseSelectable = true;
-			// 
-			// step3CounterLabel
-			// 
-			this.step3CounterLabel.Location = new System.Drawing.Point(23, 12);
-			this.step3CounterLabel.Name = "step3CounterLabel";
-			this.step3CounterLabel.Size = new System.Drawing.Size(423, 43);
-			this.step3CounterLabel.TabIndex = 10;
-			this.step3CounterLabel.Text = "3. Enter the initial counter value if known. Click the Verify button that will sh" +
+            this.counterBasedPanel.Controls.Add(this.verifyCounterButton);
+            this.counterBasedPanel.Controls.Add(this.counterField);
+            this.counterBasedPanel.Controls.Add(this.step3CounterLabel);
+            this.counterBasedPanel.Location = new System.Drawing.Point(2, 286);
+            this.counterBasedPanel.Name = "counterBasedPanel";
+            this.counterBasedPanel.Size = new System.Drawing.Size(464, 84);
+            this.counterBasedPanel.TabIndex = 16;
+            this.counterBasedPanel.Visible = false;
+            //
+            // verifyCounterButton
+            //
+            this.verifyCounterButton.Location = new System.Drawing.Point(207, 58);
+            this.verifyCounterButton.Name = "verifyCounterButton";
+            this.verifyCounterButton.Size = new System.Drawing.Size(158, 23);
+            this.verifyCounterButton.TabIndex = 1;
+            this.verifyCounterButton.Text = "Verify Authenticator";
+            this.verifyCounterButton.UseSelectable = true;
+            this.verifyCounterButton.Click += new System.EventHandler(this.verifyButton_Click);
+            //
+            // counterField
+            //
+            this.counterField.AllowDrop = true;
+            this.counterField.CausesValidation = false;
+            this.counterField.Location = new System.Drawing.Point(122, 58);
+            this.counterField.MaxLength = 32767;
+            this.counterField.Name = "counterField";
+            this.counterField.PasswordChar = '\0';
+            this.counterField.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.counterField.SelectedText = "";
+            this.counterField.Size = new System.Drawing.Size(74, 20);
+            this.counterField.TabIndex = 0;
+            this.counterField.UseSelectable = true;
+            //
+            // step3CounterLabel
+            //
+            this.step3CounterLabel.Location = new System.Drawing.Point(23, 12);
+            this.step3CounterLabel.Name = "step3CounterLabel";
+            this.step3CounterLabel.Size = new System.Drawing.Size(423, 43);
+            this.step3CounterLabel.TabIndex = 10;
+            this.step3CounterLabel.Text = "3. Enter the initial counter value if known. Click the Verify button that will sh" +
     "ow the last code that was used.";
-			// 
-			// secretCodeButton
-			// 
-			this.secretCodeButton.Location = new System.Drawing.Point(360, 171);
-			this.secretCodeButton.Name = "secretCodeButton";
-			this.secretCodeButton.Size = new System.Drawing.Size(75, 23);
-			this.secretCodeButton.TabIndex = 2;
-			this.secretCodeButton.Text = "Decode";
-			this.secretCodeButton.UseSelectable = true;
-			this.secretCodeButton.Click += new System.EventHandler(this.secretCodeButton_Click);
-			// 
-			// AddAuthenticator
-			// 
-			this.AcceptButton = this.okButton;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.BorderStyle = MetroFramework.Forms.MetroFormBorderStyle.FixedSingle;
-			this.CancelButton = this.cancelButton;
-			this.ClientSize = new System.Drawing.Size(471, 516);
-			this.Controls.Add(this.secretCodeButton);
-			this.Controls.Add(this.counterBasedPanel);
-			this.Controls.Add(this.timeBasedPanel);
-			this.Controls.Add(this.counterBasedRadio);
-			this.Controls.Add(this.timeBasedRadio);
-			this.Controls.Add(this.codeProgress);
-			this.Controls.Add(this.codeField);
-			this.Controls.Add(this.step4Label);
-			this.Controls.Add(this.step2Label);
-			this.Controls.Add(this.cancelButton);
-			this.Controls.Add(this.okButton);
-			this.Controls.Add(this.secretCodeField);
-			this.Controls.Add(this.nameLabel);
-			this.Controls.Add(this.nameField);
-			this.Controls.Add(this.step1Label);
-			this.MaximizeBox = false;
-			this.Name = "AddAuthenticator";
-			this.Resizable = false;
-			this.ShowIcon = false;
-			this.Text = "Add Authenticator";
-			this.Load += new System.EventHandler(this.AddAuthenticator_Load);
-			this.timeBasedPanel.ResumeLayout(false);
-			this.counterBasedPanel.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            //
+            // secretCodeButton
+            //
+            this.secretCodeButton.Location = new System.Drawing.Point(360, 171);
+            this.secretCodeButton.Name = "secretCodeButton";
+            this.secretCodeButton.Size = new System.Drawing.Size(75, 23);
+            this.secretCodeButton.TabIndex = 2;
+            this.secretCodeButton.Text = "Decode";
+            this.secretCodeButton.UseSelectable = true;
+            this.secretCodeButton.Click += new System.EventHandler(this.secretCodeButton_Click);
+            //
+            // AddAuthenticator
+            //
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BorderStyle = MetroFramework.Forms.MetroFormBorderStyle.FixedSingle;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(471, 516);
+            this.Controls.Add(this.secretCodeButton);
+            this.Controls.Add(this.counterBasedPanel);
+            this.Controls.Add(this.timeBasedPanel);
+            this.Controls.Add(this.counterBasedRadio);
+            this.Controls.Add(this.timeBasedRadio);
+            this.Controls.Add(this.codeProgress);
+            this.Controls.Add(this.codeField);
+            this.Controls.Add(this.step4Label);
+            this.Controls.Add(this.step2Label);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.secretCodeField);
+            this.Controls.Add(this.nameLabel);
+            this.Controls.Add(this.nameField);
+            this.Controls.Add(this.step1Label);
+            this.MaximizeBox = false;
+            this.Name = "AddAuthenticator";
+            this.Resizable = false;
+            this.ShowIcon = false;
+            this.Text = "Add Authenticator";
+            this.Load += new System.EventHandler(this.AddAuthenticator_Load);
+            this.timeBasedPanel.ResumeLayout(false);
+            this.counterBasedPanel.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
-		}
+        }
 
-		#endregion
+        #endregion
 
-		private MetroFramework.Controls.MetroLabel step1Label;
-		private MetroFramework.Controls.MetroButton okButton;
-		private MetroFramework.Controls.MetroButton cancelButton;
-		private MetroFramework.Controls.MetroTextBox secretCodeField;
-		private MetroFramework.Controls.MetroLabel nameLabel;
-		private MetroFramework.Controls.MetroTextBox nameField;
-		private MetroFramework.Controls.MetroLabel step2Label;
-		private MetroFramework.Controls.MetroButton verifyButton;
-		private System.Windows.Forms.ProgressBar codeProgress;
-		private SecretTextBox codeField;
-		private MetroFramework.Controls.MetroLabel step4Label;
-		private System.Windows.Forms.Timer timer;
-		private MetroFramework.Controls.MetroLabel step3Label;
-		private MetroFramework.Controls.MetroRadioButton timeBasedRadio;
-		private MetroFramework.Controls.MetroRadioButton counterBasedRadio;
-		private System.Windows.Forms.Panel timeBasedPanel;
-		private System.Windows.Forms.Panel counterBasedPanel;
-		private MetroFramework.Controls.MetroLabel step3CounterLabel;
-		private MetroFramework.Controls.MetroTextBox counterField;
-		private MetroFramework.Controls.MetroButton verifyCounterButton;
-		private MetroFramework.Controls.MetroButton secretCodeButton;
-	}
+        private MetroFramework.Controls.MetroLabel step1Label;
+        private MetroFramework.Controls.MetroButton okButton;
+        private MetroFramework.Controls.MetroButton cancelButton;
+        private MetroFramework.Controls.MetroTextBox secretCodeField;
+        private MetroFramework.Controls.MetroLabel nameLabel;
+        private MetroFramework.Controls.MetroTextBox nameField;
+        private MetroFramework.Controls.MetroLabel step2Label;
+        private MetroFramework.Controls.MetroButton verifyButton;
+        private System.Windows.Forms.ProgressBar codeProgress;
+        private SecretTextBox codeField;
+        private MetroFramework.Controls.MetroLabel step4Label;
+        private System.Windows.Forms.Timer timer;
+        private MetroFramework.Controls.MetroLabel step3Label;
+        private MetroFramework.Controls.MetroRadioButton timeBasedRadio;
+        private MetroFramework.Controls.MetroRadioButton counterBasedRadio;
+        private System.Windows.Forms.Panel timeBasedPanel;
+        private System.Windows.Forms.Panel counterBasedPanel;
+        private MetroFramework.Controls.MetroLabel step3CounterLabel;
+        private MetroFramework.Controls.MetroTextBox counterField;
+        private MetroFramework.Controls.MetroButton verifyCounterButton;
+        private MetroFramework.Controls.MetroButton secretCodeButton;
+    }
 }

--- a/WinAuth/AuthenticatorListBox.cs
+++ b/WinAuth/AuthenticatorListBox.cs
@@ -1949,7 +1949,7 @@ namespace WinAuth
 								code = code.Insert(code.Length / 2, " ");
 							}
 						}
-						catch (EncrpytedSecretDataException )
+						catch (EncryptedSecretDataException )
 						{
 							code = "- - - - - -";
 						}

--- a/WinAuth/HotKeySequence.cs
+++ b/WinAuth/HotKeySequence.cs
@@ -169,7 +169,7 @@ namespace WinAuth
 									// we use an explicit password to encrypt data
 									if (string.IsNullOrEmpty(password) == true)
 									{
-										throw new EncrpytedSecretDataException();
+										throw new EncryptedSecretDataException();
 									}
 									data = Authenticator.Decrypt(data, password, (version >= (decimal)1.7)); // changed encrypted in 1.7
 									byte[] plain = Authenticator.StringToByteArray(data);
@@ -266,7 +266,7 @@ namespace WinAuth
                         // we use an explicit password to encrypt data
                         if (string.IsNullOrEmpty(password) == true)
                         {
-                          throw new EncrpytedSecretDataException();
+                          throw new EncryptedSecretDataException();
                         }
                         data = Authenticator.Decrypt(data, password, true);
                         byte[] plain = Authenticator.StringToByteArray(data);

--- a/WinAuth/WinAuthAuthenticator.cs
+++ b/WinAuth/WinAuthAuthenticator.cs
@@ -34,433 +34,433 @@ using WinAuth.Resources;
 
 namespace WinAuth
 {
-	public interface IWinAuthAuthenticatorChangedListener
-	{
-		void OnWinAuthAuthenticatorChanged(WinAuthAuthenticator sender, WinAuthAuthenticatorChangedEventArgs e);
-	}
-
-	/// <summary>
-	/// Wrapper for real authenticator data used to save to file with other application information
-	/// </summary>
-  public class WinAuthAuthenticator : ICloneable
-  {
-    /// <summary>
-    /// Event handler fired when property is changed
-    /// </summary>
-		public event WinAuthAuthenticatorChangedHandler OnWinAuthAuthenticatorChanged;
-
-		/// <summary>
-		/// Unique Id of authenticator saved in config
-		/// </summary>
-    public Guid Id { get; set; }
-
-		/// <summary>
-		/// Index for authenticator when in sorted list
-		/// </summary>
-		public int Index { get; set; }
-
-		/// <summary>
-		/// Actual authenticator data
-		/// </summary>
-    public Authenticator AuthenticatorData { get; set; }
-
-		/// <summary>
-		/// When this authenticator was created
-		/// </summary>
-    public DateTime Created { get; set; }
-
-		private string _name;
-		private string _skin;
-    private bool _autoRefresh;
-    private bool _allowCopy;
-    private bool _copyOnCode;
-    private bool _hideSerial;
-    private HotKey _hotkey;
-
-		/// <summary>
-		/// Create the authenticator wrapper
-		/// </summary>
-    public WinAuthAuthenticator()
+    public interface IWinAuthAuthenticatorChangedListener
     {
-      Id = Guid.NewGuid();
-      Created = DateTime.Now;
-      _autoRefresh = true;
-    }
-
-		/// <summary>
-		/// Clone this authenticator
-		/// </summary>
-		/// <returns></returns>
-    public object Clone()
-    {
-      WinAuthAuthenticator clone = this.MemberwiseClone() as WinAuthAuthenticator;
-
-      clone.Id = Guid.NewGuid();
-			clone.OnWinAuthAuthenticatorChanged = null;
-      clone.AuthenticatorData = (this.AuthenticatorData != null ? this.AuthenticatorData.Clone() as Authenticator : null);
-
-      return clone;
-    }
-
-		/// <summary>
-		/// Mark this authenticator as having changed
-		/// </summary>
-		public void MarkChanged()
-		{
-			if (OnWinAuthAuthenticatorChanged != null)
-			{
-				OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs());
-			}
-		}
-
-		/// <summary>
-		/// Get/set the name of this authenticator
-		/// </summary>
-		public string Name
-		{
-			get
-			{
-				return _name;
-			}
-			set
-			{
-				_name = value;
-				if (OnWinAuthAuthenticatorChanged != null)
-				{
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("Name"));
-				}
-			}
-		}
-
-		/// <summary>
-		/// Set the skin for the authenticator (used for Icon)
-		/// </summary>
-		public string Skin
-    {
-      get
-      {
-        return _skin;
-      }
-      set
-      {
-        _skin = value;
-        if (OnWinAuthAuthenticatorChanged != null)
-        {
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("Skin"));
-        }
-      }
+        void OnWinAuthAuthenticatorChanged(WinAuthAuthenticator sender, WinAuthAuthenticatorChangedEventArgs e);
     }
 
     /// <summary>
-    /// Get/set auto refresh flag
+    /// Wrapper for real authenticator data used to save to file with other application information
     /// </summary>
-    public bool AutoRefresh
+    public class WinAuthAuthenticator : ICloneable
     {
-      get
-      {
-				if (this.AuthenticatorData != null && this.AuthenticatorData is HOTPAuthenticator)
-				{
-					return false;
-				}
-				else
-				{
-					return _autoRefresh;
-				}
-      }
-      set
-      {
-				// HTOP must always be false
-				if (this.AuthenticatorData != null && this.AuthenticatorData is HOTPAuthenticator)
-				{
-					_autoRefresh = false;
-				}
-				else
-				{
-					_autoRefresh = value;
-				}
-				if (OnWinAuthAuthenticatorChanged != null)
+        /// <summary>
+        /// Event handler fired when property is changed
+        /// </summary>
+        public event WinAuthAuthenticatorChangedHandler OnWinAuthAuthenticatorChanged;
+
+        /// <summary>
+        /// Unique Id of authenticator saved in config
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Index for authenticator when in sorted list
+        /// </summary>
+        public int Index { get; set; }
+
+        /// <summary>
+        /// Actual authenticator data
+        /// </summary>
+        public Authenticator AuthenticatorData { get; set; }
+
+        /// <summary>
+        /// When this authenticator was created
+        /// </summary>
+        public DateTime Created { get; set; }
+
+        private string _name;
+        private string _skin;
+        private bool _autoRefresh;
+        private bool _allowCopy;
+        private bool _copyOnCode;
+        private bool _hideSerial;
+        private HotKey _hotkey;
+
+        /// <summary>
+        /// Create the authenticator wrapper
+        /// </summary>
+        public WinAuthAuthenticator()
         {
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("AutoRefresh"));
+            Id = Guid.NewGuid();
+            Created = DateTime.Now;
+            _autoRefresh = true;
         }
-      }
-    }
 
-    /// <summary>
-    /// Get/set allow copy flag
-    /// </summary>
-    public bool AllowCopy
-    {
-      get
-      {
-        return _allowCopy;
-      }
-      set
-      {
-        _allowCopy = value;
-				if (OnWinAuthAuthenticatorChanged != null)
+        /// <summary>
+        /// Clone this authenticator
+        /// </summary>
+        /// <returns></returns>
+        public object Clone()
         {
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("AllowCopy"));
-        }
-      }
-    }
+            WinAuthAuthenticator clone = this.MemberwiseClone() as WinAuthAuthenticator;
 
-    /// <summary>
-    /// Get/set auto copy flag
-    /// </summary>
-    public bool CopyOnCode
-    {
-      get
-      {
-        return _copyOnCode;
-      }
-      set
-      {
-        _copyOnCode = value;
-				if (OnWinAuthAuthenticatorChanged != null)
+            clone.Id = Guid.NewGuid();
+            clone.OnWinAuthAuthenticatorChanged = null;
+            clone.AuthenticatorData = (this.AuthenticatorData != null ? this.AuthenticatorData.Clone() as Authenticator : null);
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Mark this authenticator as having changed
+        /// </summary>
+        public void MarkChanged()
         {
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("CopyOnCode"));
+            if (OnWinAuthAuthenticatorChanged != null)
+            {
+                OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs());
+            }
         }
-      }
-    }
 
-    /// <summary>
-    /// Get/set hide serial flag
-    /// </summary>
-    public bool HideSerial
-    {
-      get
-      {
-        return _hideSerial;
-      }
-      set
-      {
-        _hideSerial = value;
-				if (OnWinAuthAuthenticatorChanged != null)
+        /// <summary>
+        /// Get/set the name of this authenticator
+        /// </summary>
+        public string Name
         {
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HideSerial"));
+            get
+            {
+                return _name;
+            }
+            set
+            {
+                _name = value;
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("Name"));
+                }
+            }
         }
-      }
-    }
 
-		/// <summary>
-		/// Get/set the ketkey
-		/// </summary>
-		public HotKey HotKey
-		{
-			get
-			{
-				//if (this.AuthenticatorData != null && _hotkey != null)
-				//{
-				//	_hotkey.Advanced = this.AuthenticatorData.Script;
-				//}
-				return _hotkey;
-			}
-			set
-			{
-				_hotkey = value;
-				//if (this.AuthenticatorData != null && _hotkey != null)
-				//{
-				//	AuthenticatorData.Script = _hotkey.Advanced;
-				//}
-				if (OnWinAuthAuthenticatorChanged != null)
-				{
-					OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HotKey"));
-				}
-			}
-		}
+        /// <summary>
+        /// Set the skin for the authenticator (used for Icon)
+        /// </summary>
+        public string Skin
+        {
+            get
+            {
+                return _skin;
+            }
+            set
+            {
+                _skin = value;
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("Skin"));
+                }
+            }
+        }
 
-		//public HoyKeySequence AutoLogin
-		//{
-		//	get
-		//	{
-		//		string script = this.AuthenticatorData.Script;
-		//		if (string.IsNullOrEmpty(script) == true)
-		//		{
-		//			return null;
-		//		}
+        /// <summary>
+        /// Get/set auto refresh flag
+        /// </summary>
+        public bool AutoRefresh
+        {
+            get
+            {
+                if (this.AuthenticatorData != null && this.AuthenticatorData is HOTPAuthenticator)
+                {
+                    return false;
+                }
+                else
+                {
+                    return _autoRefresh;
+                }
+            }
+            set
+            {
+                // HTOP must always be false
+                if (this.AuthenticatorData != null && this.AuthenticatorData is HOTPAuthenticator)
+                {
+                    _autoRefresh = false;
+                }
+                else
+                {
+                    _autoRefresh = value;
+                }
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("AutoRefresh"));
+                }
+            }
+        }
 
-		//		HoyKeySequence hks = new HoyKeySequence();
-		//		using (XmlReader xr = XmlReader.Create(new StringReader(script)))
-		//		{
-		//			hks.ReadXml(xr);
-		//		}
-		//		return hks;
-		//	}
-		//	set
-		//	{
-		//		StringBuilder script = new StringBuilder();
-		//		if (value != null)
-		//		{
-		//			using (XmlWriter xw = XmlWriter.Create(script))
-		//			{
-		//				value.WriteXmlString(xw);
-		//			}
-		//		}
-		//		this.AuthenticatorData.Script = (script.Length != 0 ? script.ToString() : null);
+        /// <summary>
+        /// Get/set allow copy flag
+        /// </summary>
+        public bool AllowCopy
+        {
+            get
+            {
+                return _allowCopy;
+            }
+            set
+            {
+                _allowCopy = value;
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("AllowCopy"));
+                }
+            }
+        }
 
-		//		if (OnWinAuthAuthenticatorChanged != null)
-		//		{
-		//			OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs());
-		//		}
-		//	}
-		//}
+        /// <summary>
+        /// Get/set auto copy flag
+        /// </summary>
+        public bool CopyOnCode
+        {
+            get
+            {
+                return _copyOnCode;
+            }
+            set
+            {
+                _copyOnCode = value;
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("CopyOnCode"));
+                }
+            }
+        }
 
-		public Bitmap Icon
-		{
-			get
-			{
-				if (string.IsNullOrEmpty(this.Skin) == false)
-				{
-					Stream stream;
-					if (this.Skin.StartsWith("base64:") == true)
-					{
-						byte[] bytes = Convert.FromBase64String(this.Skin.Substring(7));
-						stream = new MemoryStream(bytes, 0, bytes.Length);
-					}
-					else
-					{
-						stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("WinAuth.Resources." + this.Skin);
-					}
-					if (stream != null)
-					{
-						return new Bitmap(stream);
-					}
-				}
+        /// <summary>
+        /// Get/set hide serial flag
+        /// </summary>
+        public bool HideSerial
+        {
+            get
+            {
+                return _hideSerial;
+            }
+            set
+            {
+                _hideSerial = value;
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HideSerial"));
+                }
+            }
+        }
 
-				if (AuthenticatorData == null)
-				{
-					return null;
-				}
+        /// <summary>
+        /// Get/set the ketkey
+        /// </summary>
+        public HotKey HotKey
+        {
+            get
+            {
+                //if (this.AuthenticatorData != null && _hotkey != null)
+                //{
+                //	_hotkey.Advanced = this.AuthenticatorData.Script;
+                //}
+                return _hotkey;
+            }
+            set
+            {
+                _hotkey = value;
+                //if (this.AuthenticatorData != null && _hotkey != null)
+                //{
+                //	AuthenticatorData.Script = _hotkey.Advanced;
+                //}
+                if (OnWinAuthAuthenticatorChanged != null)
+                {
+                    OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HotKey"));
+                }
+            }
+        }
 
-				return new Bitmap(Assembly.GetExecutingAssembly().GetManifestResourceStream("WinAuth.Resources." + AuthenticatorData.GetType().Name + "Icon.png"));
-			}
-			set
-			{
-				if (value == null)
-				{
-					this.Skin = null;
-					return;
-				}
+        //public HoyKeySequence AutoLogin
+        //{
+        //	get
+        //	{
+        //		string script = this.AuthenticatorData.Script;
+        //		if (string.IsNullOrEmpty(script) == true)
+        //		{
+        //			return null;
+        //		}
 
-				using (MemoryStream ms = new MemoryStream())
-				{
-					value.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-					this.Skin = "base64:" + Convert.ToBase64String(ms.ToArray());
-				}
-			}
-		}
+        //		HoyKeySequence hks = new HoyKeySequence();
+        //		using (XmlReader xr = XmlReader.Create(new StringReader(script)))
+        //		{
+        //			hks.ReadXml(xr);
+        //		}
+        //		return hks;
+        //	}
+        //	set
+        //	{
+        //		StringBuilder script = new StringBuilder();
+        //		if (value != null)
+        //		{
+        //			using (XmlWriter xw = XmlWriter.Create(script))
+        //			{
+        //				value.WriteXmlString(xw);
+        //			}
+        //		}
+        //		this.AuthenticatorData.Script = (script.Length != 0 ? script.ToString() : null);
 
-		public string CurrentCode
-		{
-			get
-			{
-				if (this.AuthenticatorData == null)
-				{
-					return null;
-				}
+        //		if (OnWinAuthAuthenticatorChanged != null)
+        //		{
+        //			OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs());
+        //		}
+        //	}
+        //}
 
-				string code = this.AuthenticatorData.CurrentCode;
-		
-				if (this.AuthenticatorData is HOTPAuthenticator)
-				{
-					if (OnWinAuthAuthenticatorChanged != null)
-					{
-						OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HOTP", this.AuthenticatorData));
-					}
-				}
+        public Bitmap Icon
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(this.Skin) == false)
+                {
+                    Stream stream;
+                    if (this.Skin.StartsWith("base64:") == true)
+                    {
+                        byte[] bytes = Convert.FromBase64String(this.Skin.Substring(7));
+                        stream = new MemoryStream(bytes, 0, bytes.Length);
+                    }
+                    else
+                    {
+                        stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("WinAuth.Resources." + this.Skin);
+                    }
+                    if (stream != null)
+                    {
+                        return new Bitmap(stream);
+                    }
+                }
 
-				return code;
-			}
-		}
+                if (AuthenticatorData == null)
+                {
+                    return null;
+                }
 
-		/// <summary>
-		/// Sync the current authenticator's time with its server
-		/// </summary>
-		public void Sync()
-		{
-			if (AuthenticatorData != null)
-			{
-				try
-				{
-					AuthenticatorData.Sync();
-				}
-				catch (EncryptedSecretDataException)
-				{
-					// reset lastsync to force sync on next decryption
-				}
-			}
-		}
+                return new Bitmap(Assembly.GetExecutingAssembly().GetManifestResourceStream("WinAuth.Resources." + AuthenticatorData.GetType().Name + "Icon.png"));
+            }
+            set
+            {
+                if (value == null)
+                {
+                    this.Skin = null;
+                    return;
+                }
 
-		/// <summary>
-		/// Copy the current code to the clipboard
-		/// </summary>
-		public void CopyCodeToClipboard(Form form, string code = null, bool showError = false)
-		{
-			if (code == null)
-			{
-				code = this.CurrentCode;
-			}
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    value.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                    this.Skin = "base64:" + Convert.ToBase64String(ms.ToArray());
+                }
+            }
+        }
 
-			bool clipRetry = false;
-			do
-			{
-				bool failed = false;
-				// check if the clipboard is locked
-				IntPtr hWnd = WinAPI.GetOpenClipboardWindow();
-				if (hWnd != IntPtr.Zero)
-				{
-					int len = WinAPI.GetWindowTextLength(hWnd);
-					if (len == 0)
-					{
-						WinAuthMain.LogException(new ApplicationException("Clipboard in use by another process"));
-					}
-					else
-					{
-						StringBuilder sb = new StringBuilder(len + 1);
-						WinAPI.GetWindowText(hWnd, sb, sb.Capacity);
-						WinAuthMain.LogException(new ApplicationException("Clipboard in use by '" + sb.ToString() + "'"));
-					}
+        public string CurrentCode
+        {
+            get
+            {
+                if (this.AuthenticatorData == null)
+                {
+                    return null;
+                }
 
-					failed = true;
-				}
-				else
-				{
-					// Issue#170: can still get error copying even though it works, so just increase retries and ignore error
-					try
-					{
-						Clipboard.Clear();
+                string code = this.AuthenticatorData.CurrentCode;
 
-						// add delay for clip error
-						System.Threading.Thread.Sleep(100);
+                if (this.AuthenticatorData is HOTPAuthenticator)
+                {
+                    if (OnWinAuthAuthenticatorChanged != null)
+                    {
+                        OnWinAuthAuthenticatorChanged(this, new WinAuthAuthenticatorChangedEventArgs("HOTP", this.AuthenticatorData));
+                    }
+                }
 
-						Clipboard.SetDataObject(code, true, 4, 250);
-					}
-					catch (ExternalException )
-					{
-					}
-				}
+                return code;
+            }
+        }
 
-				if (failed == true && showError == true)
-				{
-					// only show an error the first time
-					clipRetry = (MessageBox.Show(form, strings.ClipboardInUse,
-						WinAuthMain.APPLICATION_NAME,
-						MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.Yes);
-				}
-			}
-			while (clipRetry == true);
-		}
+        /// <summary>
+        /// Sync the current authenticator's time with its server
+        /// </summary>
+        public void Sync()
+        {
+            if (AuthenticatorData != null)
+            {
+                try
+                {
+                    AuthenticatorData.Sync();
+                }
+                catch (EncryptedSecretDataException)
+                {
+                    // reset lastsync to force sync on next decryption
+                }
+            }
+        }
 
-    public bool ReadXml(XmlReader reader, string password)
-    {
-			bool changed = false;
+        /// <summary>
+        /// Copy the current code to the clipboard
+        /// </summary>
+        public void CopyCodeToClipboard(Form form, string code = null, bool showError = false)
+        {
+            if (code == null)
+            {
+                code = this.CurrentCode;
+            }
 
-      Guid id;
+            bool clipRetry = false;
+            do
+            {
+                bool failed = false;
+                // check if the clipboard is locked
+                IntPtr hWnd = WinAPI.GetOpenClipboardWindow();
+                if (hWnd != IntPtr.Zero)
+                {
+                    int len = WinAPI.GetWindowTextLength(hWnd);
+                    if (len == 0)
+                    {
+                        WinAuthMain.LogException(new ApplicationException("Clipboard in use by another process"));
+                    }
+                    else
+                    {
+                        StringBuilder sb = new StringBuilder(len + 1);
+                        WinAPI.GetWindowText(hWnd, sb, sb.Capacity);
+                        WinAuthMain.LogException(new ApplicationException("Clipboard in use by '" + sb.ToString() + "'"));
+                    }
+
+                    failed = true;
+                }
+                else
+                {
+                    // Issue#170: can still get error copying even though it works, so just increase retries and ignore error
+                    try
+                    {
+                        Clipboard.Clear();
+
+                        // add delay for clip error
+                        System.Threading.Thread.Sleep(100);
+
+                        Clipboard.SetDataObject(code, true, 4, 250);
+                    }
+                    catch (ExternalException)
+                    {
+                    }
+                }
+
+                if (failed == true && showError == true)
+                {
+                    // only show an error the first time
+                    clipRetry = (MessageBox.Show(form, strings.ClipboardInUse,
+                        WinAuthMain.APPLICATION_NAME,
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.Yes);
+                }
+            }
+            while (clipRetry == true);
+        }
+
+        public bool ReadXml(XmlReader reader, string password)
+        {
+            bool changed = false;
+
+            Guid id;
 #if NETFX_4
-			if (Guid.TryParse(reader.GetAttribute("id"), out id) == true)
-      {
-        Id = id;
-      }
+            if (Guid.TryParse(reader.GetAttribute("id"), out id) == true)
+            {
+                Id = id;
+            }
 #endif
 #if NETFX_3
 			try
@@ -471,316 +471,316 @@ namespace WinAuth
 			catch (Exception) { }
 #endif
 
-			string authenticatorType = reader.GetAttribute("type");
-      if (string.IsNullOrEmpty(authenticatorType) == false)
-      {
-        Type type = typeof(Authenticator).Assembly.GetType(authenticatorType, false, true);
-        this.AuthenticatorData = Activator.CreateInstance(type) as Authenticator;
-      }
+            string authenticatorType = reader.GetAttribute("type");
+            if (string.IsNullOrEmpty(authenticatorType) == false)
+            {
+                Type type = typeof(Authenticator).Assembly.GetType(authenticatorType, false, true);
+                this.AuthenticatorData = Activator.CreateInstance(type) as Authenticator;
+            }
 
-			//string encrypted = reader.GetAttribute("encrypted");
-			//if (string.IsNullOrEmpty(encrypted) == false)
-			//{
-			//	// read the encrypted text from the node
-			//	string data = reader.ReadElementContentAsString();
-			//	// decrypt
-			//	Authenticator.PasswordTypes passwordType;
-			//	data = Authenticator.DecryptSequence(data, encrypted, password, out passwordType);
+            //string encrypted = reader.GetAttribute("encrypted");
+            //if (string.IsNullOrEmpty(encrypted) == false)
+            //{
+            //	// read the encrypted text from the node
+            //	string data = reader.ReadElementContentAsString();
+            //	// decrypt
+            //	Authenticator.PasswordTypes passwordType;
+            //	data = Authenticator.DecryptSequence(data, encrypted, password, out passwordType);
 
-			//	using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
-			//	{
-			//		reader = XmlReader.Create(ms);
-			//		ReadXml(reader, password);
-			//	}
-			//	this.PasswordType = passwordType;
-			//	this.Password = password;
+            //	using (MemoryStream ms = new MemoryStream(Authenticator.StringToByteArray(data)))
+            //	{
+            //		reader = XmlReader.Create(ms);
+            //		ReadXml(reader, password);
+            //	}
+            //	this.PasswordType = passwordType;
+            //	this.Password = password;
 
-			//	return;
-			//}
+            //	return;
+            //}
 
-      reader.MoveToContent();
+            reader.MoveToContent();
 
-      if (reader.IsEmptyElement)
-      {
-        reader.Read();
-        return changed;
-      }
+            if (reader.IsEmptyElement)
+            {
+                reader.Read();
+                return changed;
+            }
 
-      reader.Read();
-      while (reader.EOF == false)
-      {
-        if (reader.IsStartElement())
-        {
-          switch (reader.Name)
-          {
-            case "name":
-              Name = reader.ReadElementContentAsString();
-              break;
+            reader.Read();
+            while (reader.EOF == false)
+            {
+                if (reader.IsStartElement())
+                {
+                    switch (reader.Name)
+                    {
+                        case "name":
+                            Name = reader.ReadElementContentAsString();
+                            break;
 
-            case "created":
-              long t = reader.ReadElementContentAsLong();
-              t += Convert.ToInt64(new TimeSpan(new DateTime(1970, 1, 1).Ticks).TotalMilliseconds);
-              t *= TimeSpan.TicksPerMillisecond;
-              Created = new DateTime(t).ToLocalTime();
-              break;
+                        case "created":
+                            long t = reader.ReadElementContentAsLong();
+                            t += Convert.ToInt64(new TimeSpan(new DateTime(1970, 1, 1).Ticks).TotalMilliseconds);
+                            t *= TimeSpan.TicksPerMillisecond;
+                            Created = new DateTime(t).ToLocalTime();
+                            break;
 
-            case "autorefresh":
-              _autoRefresh = reader.ReadElementContentAsBoolean();
-              break;
+                        case "autorefresh":
+                            _autoRefresh = reader.ReadElementContentAsBoolean();
+                            break;
 
-            case "allowcopy":
-              _allowCopy= reader.ReadElementContentAsBoolean();
-              break;
+                        case "allowcopy":
+                            _allowCopy = reader.ReadElementContentAsBoolean();
+                            break;
 
-            case "copyoncode":
-              _copyOnCode = reader.ReadElementContentAsBoolean();
-              break;
+                        case "copyoncode":
+                            _copyOnCode = reader.ReadElementContentAsBoolean();
+                            break;
 
-            case "hideserial":
-              _hideSerial = reader.ReadElementContentAsBoolean();
-              break;
+                        case "hideserial":
+                            _hideSerial = reader.ReadElementContentAsBoolean();
+                            break;
 
-            case "skin":
-              _skin = reader.ReadElementContentAsString();
-              break;
+                        case "skin":
+                            _skin = reader.ReadElementContentAsString();
+                            break;
 
-						case "hotkey":
-							_hotkey = new WinAuth.HotKey();
-							_hotkey.ReadXml(reader);
-							break;
+                        case "hotkey":
+                            _hotkey = new WinAuth.HotKey();
+                            _hotkey.ReadXml(reader);
+                            break;
 
-						case "authenticatordata":
-							try
-							{
-								// we don't pass the password as they are locked till clicked
-								changed = this.AuthenticatorData.ReadXml(reader) || changed;
-							}
-							catch (EncryptedSecretDataException )
-							{
-								// no action needed
-							}
-							catch (BadPasswordException)
-							{
-								// no action needed
-							}
-              break;
+                        case "authenticatordata":
+                            try
+                            {
+                                // we don't pass the password as they are locked till clicked
+                                changed = this.AuthenticatorData.ReadXml(reader) || changed;
+                            }
+                            catch (EncryptedSecretDataException)
+                            {
+                                // no action needed
+                            }
+                            catch (BadPasswordException)
+                            {
+                                // no action needed
+                            }
+                            break;
 
-						// v2
-						case "authenticator":
-							this.AuthenticatorData = Authenticator.ReadXmlv2(reader, password);
-							break;
-						// v2
-						case "autologin":
-              var hks = new HoyKeySequence();
-              hks.ReadXml(reader, password);
-              break;
-						// v2
-						case "servertimediff":
-							this.AuthenticatorData.ServerTimeDiff = reader.ReadElementContentAsLong();
-							break;
+                        // v2
+                        case "authenticator":
+                            this.AuthenticatorData = Authenticator.ReadXmlv2(reader, password);
+                            break;
+                        // v2
+                        case "autologin":
+                            var hks = new HoyKeySequence();
+                            hks.ReadXml(reader, password);
+                            break;
+                        // v2
+                        case "servertimediff":
+                            this.AuthenticatorData.ServerTimeDiff = reader.ReadElementContentAsLong();
+                            break;
 
 
-            default:
-              reader.Skip();
-              break;
-          }
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+                else
+                {
+                    reader.Read();
+                    break;
+                }
+            }
+
+            return changed;
         }
-        else
-        {
-          reader.Read();
-          break;
-        }
-      }
 
-			return changed;
+        /// <summary>
+        /// Write the data as xml into an XmlWriter
+        /// </summary>
+        /// <param name="writer">XmlWriter to write config</param>
+        public void WriteXmlString(XmlWriter writer)
+        {
+            writer.WriteStartElement(typeof(WinAuthAuthenticator).Name);
+            writer.WriteAttributeString("id", this.Id.ToString());
+            if (this.AuthenticatorData != null)
+            {
+                writer.WriteAttributeString("type", this.AuthenticatorData.GetType().FullName);
+            }
+
+            //if (this.PasswordType != Authenticator.PasswordTypes.None)
+            //{
+            //	string data;
+
+            //	using (MemoryStream ms = new MemoryStream())
+            //	{
+            //		XmlWriterSettings settings = new XmlWriterSettings();
+            //		settings.Indent = true;
+            //		settings.Encoding = Encoding.UTF8;
+            //		using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
+            //		{
+            //			Authenticator.PasswordTypes savedpasswordType = PasswordType;
+            //			PasswordType = Authenticator.PasswordTypes.None;
+            //			WriteXmlString(encryptedwriter);
+            //			PasswordType = savedpasswordType;
+            //		}
+            //		//data = Encoding.UTF8.GetString(ms.ToArray());
+            //		data = Authenticator.ByteArrayToString(ms.ToArray());
+            //	}
+
+            //	string encryptedTypes;
+            //	data = Authenticator.EncryptSequence(data, PasswordType, Password, out encryptedTypes);
+            //	writer.WriteAttributeString("encrypted", encryptedTypes);
+            //	writer.WriteString(data);
+            //	writer.WriteEndElement();
+
+            //	return;
+            //}
+
+            writer.WriteStartElement("name");
+            writer.WriteValue(this.Name ?? string.Empty);
+            writer.WriteEndElement();
+
+            writer.WriteStartElement("created");
+            writer.WriteValue(Convert.ToInt64((this.Created.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalMilliseconds));
+            writer.WriteEndElement();
+
+            writer.WriteStartElement("autorefresh");
+            writer.WriteValue(this.AutoRefresh);
+            writer.WriteEndElement();
+            //
+            writer.WriteStartElement("allowcopy");
+            writer.WriteValue(this.AllowCopy);
+            writer.WriteEndElement();
+            //
+            writer.WriteStartElement("copyoncode");
+            writer.WriteValue(this.CopyOnCode);
+            writer.WriteEndElement();
+            //
+            writer.WriteStartElement("hideserial");
+            writer.WriteValue(this.HideSerial);
+            writer.WriteEndElement();
+            //
+            writer.WriteStartElement("skin");
+            writer.WriteValue(this.Skin ?? string.Empty);
+            writer.WriteEndElement();
+            //
+            if (this.HotKey != null)
+            {
+                this.HotKey.WriteXmlString(writer);
+            }
+
+            // save the authenticator to the config file
+            if (this.AuthenticatorData != null)
+            {
+                this.AuthenticatorData.WriteToWriter(writer);
+
+                // save script with password and generated salt
+                //if (this.AutoLogin != null)
+                //{
+                //	this.AutoLogin.WriteXmlString(writer, this.AuthenticatorData.PasswordType, this.AuthenticatorData.Password);
+                //}
+            }
+
+            writer.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Create a KeyUriFormat compatible URL
+        /// See https://code.google.com/p/google-authenticator/wiki/KeyUriFormat
+        /// </summary>
+        /// <returns>string</returns>
+        public virtual string ToUrl(bool compat = false)
+        {
+            string type = "totp";
+            string extraparams = string.Empty;
+
+            Match match;
+            string issuer = this.AuthenticatorData.Issuer;
+            string label = this.Name;
+            if (string.IsNullOrEmpty(issuer) == true && (match = Regex.Match(label, @"^([^\(]+)\s+\((.*?)\)(.*)")).Success == true)
+            {
+                issuer = match.Groups[1].Value;
+                label = match.Groups[2].Value + match.Groups[3].Value;
+            }
+            if (string.IsNullOrEmpty(issuer) == false && (match = Regex.Match(label, @"^" + issuer + @"\s+\((.*?)\)(.*)")).Success == true)
+            {
+                label = match.Groups[1].Value + match.Groups[2].Value;
+            }
+            if (string.IsNullOrEmpty(issuer) == false)
+            {
+                extraparams += "&issuer=" + HttpUtility.UrlEncode(issuer);
+            }
+
+            if (this.AuthenticatorData is BattleNetAuthenticator)
+            {
+                extraparams += "&serial=" + HttpUtility.UrlEncode(((BattleNetAuthenticator)this.AuthenticatorData).Serial.Replace("-", ""));
+            }
+            else if (this.AuthenticatorData is SteamAuthenticator)
+            {
+                if (compat == false)
+                {
+                    extraparams += "&deviceid=" + HttpUtility.UrlEncode(((SteamAuthenticator)this.AuthenticatorData).DeviceId);
+                    extraparams += "&data=" + HttpUtility.UrlEncode(((SteamAuthenticator)this.AuthenticatorData).SteamData);
+                }
+            }
+            else if (this.AuthenticatorData is HOTPAuthenticator)
+            {
+                type = "hotp";
+                extraparams += "&counter=" + ((HOTPAuthenticator)this.AuthenticatorData).Counter;
+            }
+
+            string secret = HttpUtility.UrlEncode(Base32.getInstance().Encode(this.AuthenticatorData.SecretKey));
+
+            // add the skin
+            if (string.IsNullOrEmpty(this.Skin) == false && compat == false)
+            {
+                if (this.Skin.StartsWith("base64:") == true)
+                {
+                    byte[] bytes = Convert.FromBase64String(this.Skin.Substring(7));
+                    string icon32 = Base32.getInstance().Encode(bytes);
+                    extraparams += "&icon=" + HttpUtility.UrlEncode("base64:" + icon32);
+                }
+                else
+                {
+                    extraparams += "&icon=" + HttpUtility.UrlEncode(this.Skin.Replace("Icon.png", ""));
+                }
+            }
+
+            var url = string.Format("otpauth://" + type + "/{0}?secret={1}&digits={2}{3}",
+            (string.IsNullOrEmpty(issuer) == false ? issuer + ":" + HttpUtility.UrlEncode(label) : HttpUtility.UrlEncode(label)),
+            secret,
+            this.AuthenticatorData.CodeDigits,
+            extraparams);
+
+            return url;
+        }
+
     }
 
     /// <summary>
-    /// Write the data as xml into an XmlWriter
+    /// Delegate for ConfigChange event
     /// </summary>
-    /// <param name="writer">XmlWriter to write config</param>
-    public void WriteXmlString(XmlWriter writer)
-    {
-      writer.WriteStartElement(typeof(WinAuthAuthenticator).Name);
-      writer.WriteAttributeString("id", this.Id.ToString());
-      if (this.AuthenticatorData != null)
-      {
-        writer.WriteAttributeString("type", this.AuthenticatorData.GetType().FullName);
-      }
-
-			//if (this.PasswordType != Authenticator.PasswordTypes.None)
-			//{
-			//	string data;
-
-			//	using (MemoryStream ms = new MemoryStream())
-			//	{
-			//		XmlWriterSettings settings = new XmlWriterSettings();
-			//		settings.Indent = true;
-			//		settings.Encoding = Encoding.UTF8;
-			//		using (XmlWriter encryptedwriter = XmlWriter.Create(ms, settings))
-			//		{
-			//			Authenticator.PasswordTypes savedpasswordType = PasswordType;
-			//			PasswordType = Authenticator.PasswordTypes.None;
-			//			WriteXmlString(encryptedwriter);
-			//			PasswordType = savedpasswordType;
-			//		}
-			//		//data = Encoding.UTF8.GetString(ms.ToArray());
-			//		data = Authenticator.ByteArrayToString(ms.ToArray());
-			//	}
-
-			//	string encryptedTypes;
-			//	data = Authenticator.EncryptSequence(data, PasswordType, Password, out encryptedTypes);
-			//	writer.WriteAttributeString("encrypted", encryptedTypes);
-			//	writer.WriteString(data);
-			//	writer.WriteEndElement();
-
-			//	return;
-			//}
-
-      writer.WriteStartElement("name");
-      writer.WriteValue(this.Name ?? string.Empty);
-      writer.WriteEndElement();
-
-      writer.WriteStartElement("created");
-      writer.WriteValue(Convert.ToInt64((this.Created.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalMilliseconds));
-      writer.WriteEndElement();
-
-      writer.WriteStartElement("autorefresh");
-      writer.WriteValue(this.AutoRefresh);
-      writer.WriteEndElement();
-      //
-      writer.WriteStartElement("allowcopy");
-      writer.WriteValue(this.AllowCopy);
-      writer.WriteEndElement();
-      //
-      writer.WriteStartElement("copyoncode");
-      writer.WriteValue(this.CopyOnCode);
-      writer.WriteEndElement();
-      //
-      writer.WriteStartElement("hideserial");
-      writer.WriteValue(this.HideSerial);
-      writer.WriteEndElement();
-      //
-      writer.WriteStartElement("skin");
-      writer.WriteValue(this.Skin ?? string.Empty);
-      writer.WriteEndElement();
-			//
-			if (this.HotKey != null)
-			{
-				this.HotKey.WriteXmlString(writer);
-			}
-
-      // save the authenticator to the config file
-      if (this.AuthenticatorData != null)
-      {
-        this.AuthenticatorData.WriteToWriter(writer);
-
-        // save script with password and generated salt
-				//if (this.AutoLogin != null)
-				//{
-				//	this.AutoLogin.WriteXmlString(writer, this.AuthenticatorData.PasswordType, this.AuthenticatorData.Password);
-				//}
-      }
-
-      writer.WriteEndElement();
-    }
-
-		/// <summary>
-		/// Create a KeyUriFormat compatible URL
-		/// See https://code.google.com/p/google-authenticator/wiki/KeyUriFormat
-		/// </summary>
-		/// <returns>string</returns>
-		public virtual string ToUrl(bool compat = false)
-		{
-			string type = "totp";
-			string extraparams = string.Empty;
-
-			Match match;
-			string issuer = this.AuthenticatorData.Issuer;
-			string label = this.Name;
-			if (string.IsNullOrEmpty(issuer) == true && (match = Regex.Match(label, @"^([^\(]+)\s+\((.*?)\)(.*)")).Success == true)
-			{
-				issuer = match.Groups[1].Value;
-				label = match.Groups[2].Value + match.Groups[3].Value;
-			}
-			if (string.IsNullOrEmpty(issuer) == false && (match = Regex.Match(label, @"^" + issuer + @"\s+\((.*?)\)(.*)")).Success == true)
-			{
-				label = match.Groups[1].Value + match.Groups[2].Value;
-			}
-			if (string.IsNullOrEmpty(issuer) == false)
-			{
-				extraparams += "&issuer=" + HttpUtility.UrlEncode(issuer);
-			}
-
-			if (this.AuthenticatorData is BattleNetAuthenticator)
-			{
-				extraparams += "&serial=" + HttpUtility.UrlEncode(((BattleNetAuthenticator)this.AuthenticatorData).Serial.Replace("-", ""));
-			}
-			else if (this.AuthenticatorData is SteamAuthenticator)
-			{
-				if (compat == false)
-				{
-					extraparams += "&deviceid=" + HttpUtility.UrlEncode(((SteamAuthenticator)this.AuthenticatorData).DeviceId);
-					extraparams += "&data=" + HttpUtility.UrlEncode(((SteamAuthenticator)this.AuthenticatorData).SteamData);
-				}
-			}
-			else if (this.AuthenticatorData is HOTPAuthenticator)
-			{
-				type = "hotp";
-				extraparams += "&counter=" + ((HOTPAuthenticator)this.AuthenticatorData).Counter;
-			}
-
-			string secret = HttpUtility.UrlEncode(Base32.getInstance().Encode(this.AuthenticatorData.SecretKey));
-
-			// add the skin
-			if (string.IsNullOrEmpty(this.Skin) == false && compat == false)
-			{
-				if (this.Skin.StartsWith("base64:") == true)
-				{
-					byte[] bytes = Convert.FromBase64String(this.Skin.Substring(7));
-					string icon32 = Base32.getInstance().Encode(bytes);
-					extraparams += "&icon=" + HttpUtility.UrlEncode("base64:" + icon32);
-				}
-				else
-				{
-					extraparams += "&icon=" + HttpUtility.UrlEncode(this.Skin.Replace("Icon.png", ""));
-				}
-			}
-
-			var url = string.Format("otpauth://" + type + "/{0}?secret={1}&digits={2}{3}",
-				(string.IsNullOrEmpty(issuer) == false ? issuer + ":" + HttpUtility.UrlEncode(label) : HttpUtility.UrlEncode(label)),
-				secret,
-				this.AuthenticatorData.CodeDigits,
-				extraparams);
-
-			return url;
-		}
-
-  }
-
-  /// <summary>
-  /// Delegate for ConfigChange event
-  /// </summary>
-  /// <param name="source"></param>
-  /// <param name="args"></param>
-	public delegate void WinAuthAuthenticatorChangedHandler(WinAuthAuthenticator source, WinAuthAuthenticatorChangedEventArgs args);
-
-  /// <summary>
-  /// Change event arguments
-  /// </summary>
-  public class WinAuthAuthenticatorChangedEventArgs : EventArgs
-  {
-		public string Property { get; private set; }
-		public Authenticator Authenticator { get; private set; }
+    /// <param name="source"></param>
+    /// <param name="args"></param>
+    public delegate void WinAuthAuthenticatorChangedHandler(WinAuthAuthenticator source, WinAuthAuthenticatorChangedEventArgs args);
 
     /// <summary>
-    /// Default constructor
+    /// Change event arguments
     /// </summary>
-    public WinAuthAuthenticatorChangedEventArgs(string property = null, Authenticator authenticator = null)
+    public class WinAuthAuthenticatorChangedEventArgs : EventArgs
     {
-			Property = property;
-			Authenticator = authenticator;
-    }
+        public string Property { get; private set; }
+        public Authenticator Authenticator { get; private set; }
 
-	}
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public WinAuthAuthenticatorChangedEventArgs(string property = null, Authenticator authenticator = null)
+        {
+            Property = property;
+            Authenticator = authenticator;
+        }
+
+    }
 }

--- a/WinAuth/WinAuthAuthenticator.cs
+++ b/WinAuth/WinAuthAuthenticator.cs
@@ -712,6 +712,19 @@ namespace WinAuth
                 extraparams += "&issuer=" + HttpUtility.UrlEncode(issuer);
             }
 
+            switch (this.AuthenticatorData.HMACType)
+            {
+                case HMACTypes.SHA1:
+                    // Default when unspecified.
+                    break;
+                case HMACTypes.SHA256:
+                    extraparams += "&algorithm=SHA256";
+                    break;
+                case HMACTypes.SHA512:
+                    extraparams += "&algorithm=SHA512";
+                    break;
+            }
+
             if (this.AuthenticatorData is BattleNetAuthenticator)
             {
                 extraparams += "&serial=" + HttpUtility.UrlEncode(((BattleNetAuthenticator)this.AuthenticatorData).Serial.Replace("-", ""));

--- a/WinAuth/WinAuthAuthenticator.cs
+++ b/WinAuth/WinAuthAuthenticator.cs
@@ -384,7 +384,7 @@ namespace WinAuth
 				{
 					AuthenticatorData.Sync();
 				}
-				catch (EncrpytedSecretDataException)
+				catch (EncryptedSecretDataException)
 				{
 					// reset lastsync to force sync on next decryption
 				}
@@ -555,7 +555,7 @@ namespace WinAuth
 								// we don't pass the password as they are locked till clicked
 								changed = this.AuthenticatorData.ReadXml(reader) || changed;
 							}
-							catch (EncrpytedSecretDataException )
+							catch (EncryptedSecretDataException )
 							{
 								// no action needed
 							}

--- a/WinAuth/WinAuthForm.cs
+++ b/WinAuth/WinAuthForm.cs
@@ -277,7 +277,7 @@ namespace WinAuth
 					System.Diagnostics.Process.GetCurrentProcess().Kill();
 					return;
 				}
-				else if (ex is EncrpytedSecretDataException)
+				else if (ex is EncryptedSecretDataException)
 				{
 					loadingPanel.Visible = false;
 					passwordPanel.Visible = true;
@@ -591,7 +591,7 @@ namespace WinAuth
 					needPassword = false;
 					retry = false;
 				}
-				catch (EncrpytedSecretDataException)
+				catch (EncryptedSecretDataException)
 				{
 					needPassword = true;
 					invalidPassword = false;
@@ -1307,7 +1307,7 @@ namespace WinAuth
 			{
 				code = auth.CurrentCode;
 			}
-			catch (EncrpytedSecretDataException)
+			catch (EncryptedSecretDataException)
 			{
 				// if the authenticator is current protected we display the password window, get the code, and reprotect it
 				// with a bit of window jiggling to make sure we get focus and then put it back
@@ -1381,7 +1381,7 @@ namespace WinAuth
 			{
 				code = auth.CurrentCode;
 			}
-			catch (EncrpytedSecretDataException)
+			catch (EncryptedSecretDataException)
 			{
 				// if the authenticator is current protected we display the password window, get the code, and reprotect it
 				// with a bit of window jiggling to make sure we get focus and then put it back

--- a/WinAuth/WinAuthHelper.cs
+++ b/WinAuth/WinAuthHelper.cs
@@ -669,6 +669,27 @@ namespace WinAuth
 							auth.CodeDigits = digits;
 						}
 						//
+						string hmacTypeString = query["algorithm"];
+						HMACTypes hmacType = Authenticator.DEFAULT_HMAC_TYPE;
+						if (hmacTypeString != null)
+						{
+							switch (hmacTypeString.ToUpper())
+							{
+								case "SHA1":
+									hmacType = HMACTypes.SHA1;
+									break;
+								case "SHA256":
+									hmacType = HMACTypes.SHA256;
+									break;
+								case "SHA512":
+									hmacType = HMACTypes.SHA512;
+									break;
+								default:
+									throw new ApplicationException("Unknown HMAC algorithm '" + hmacTypeString + "'");
+							}
+						}
+						auth.HMACType = hmacType;
+						//
 						if (label.Length != 0)
 						{
 							importedAuthenticator.Name = (issuer.Length != 0 ? issuer + " (" + label + ")" : label);

--- a/WinAuth/WinAuthHelper.cs
+++ b/WinAuth/WinAuthHelper.cs
@@ -219,7 +219,7 @@ namespace WinAuth
 					SaveConfig(config);
 				}
 			}
-			catch (EncrpytedSecretDataException )
+			catch (EncryptedSecretDataException )
 			{
 				// we require a password
 				throw;


### PR DESCRIPTION
Most authenticators don't need this, but I have a few more obscure ones that do. For example, the Entrust IdentityGuard authenticator uses SHA-256 instead of the much more prolific SHA-1.

I'm not super happy with this change set because of the whitespace mess. The files I touched were indented very inconsistently, so it wasn't possible to get a nice minimal changeset from the start. So I re-indented all the files I touched before I made my changes. :disappointed:
