### PR TITLE
WinAuthAuthenticator.ToUrl: use UrlPathEncode for path portion of URI

### DIFF
--- a/WinAuth/WinAuthAuthenticator.cs
+++ b/WinAuth/WinAuthAuthenticator.cs
@@ -748,7 +748,7 @@ namespace WinAuth
 			}
 
 			var url = string.Format("otpauth://" + type + "/{0}?secret={1}&digits={2}{3}",
-				(string.IsNullOrEmpty(issuer) == false ? issuer + ":" + HttpUtility.UrlEncode(label) : HttpUtility.UrlEncode(label)),
+				(string.IsNullOrEmpty(issuer) == false ? HttpUtility.UrlPathEncode(issuer) + ":" + HttpUtility.UrlPathEncode(label) : HttpUtility.UrlPathEncode(label)),
 				secret,
 				this.AuthenticatorData.CodeDigits,
 				extraparams);


### PR DESCRIPTION
There were two issues here:
- The 'issuer' was not being UrlEncoded if it was included in the path. This
  could result in invalid URIs with spaces in them if the 'issuer' has
  whitespace.
- The path portion of the URI should be encoded using UrlPathEncode rather than
  UrlEncode. See here for why: http://stackoverflow.com/a/4145961
